### PR TITLE
Create associating-authorization-policy-formconfiguration.liquid

### DIFF
--- a/marketplace_builder/pages/getting-started/authorization-policy/associating-authorization-policy-formconfiguration.liquid
+++ b/marketplace_builder/pages/getting-started/authorization-policy/associating-authorization-policy-formconfiguration.liquid
@@ -1,0 +1,73 @@
+---
+converter: markdown
+metadata:
+  title: Associating an Authorization Policy with Form Configuration
+slug: get-started/authorization-policy/associating-authorization-policy-formconfiguration
+---
+
+This guide will help you associate an Authorization Policy with Form Configuration. 
+
+## Requirements
+So that you can follow the steps in this tutorial, you should understand the concept of Authorization Policy, and you should have created an Authorization Policy. 
+
+* [Authorization Policy](/get-started/authorization-policy/authorization-policy) 
+* [Adding an Authorization Policy](/get-started/authorization-policy/adding-authorization-policy)
+
+## Steps 
+
+Associating an Authorization Policy with Form Configuration is a two-step process:
+
+1. Create Form Configuration
+2. Add `authorization_policies` key to Form Configuration
+
+### Step 1: Create Form Configuration
+Assuming you have a simple form that allows to change the user's last name, the configuration file can look like this:
+
+{% raw %}
+
+```liquid
+---
+name: update_last_name
+resource: User
+configuration:
+  last_name:
+    validation:
+      presence: {}
+---
+{% form url: "/api/users/{{ current_user.id }}" %}
+  {% input 'last_name', label: 'Last Name' %}
+  {% submit 'Save' %}
+{% endform %}
+```
+
+{% endraw %}
+
+### Step 2: Add `authorization_policies` key to Form Configuration
+In order to associate the Authorization Policy with the form, add a new `authorization_policies` key, and then specify the array of policy names associated with this form. 
+
+To ensure that only Johns will be able to submit this form, update the configuration to include the policy:
+
+{% raw %}
+
+```yml
+---
+name: update_last_name
+resource: User
+authorization_policies:
+  - only_allowed_by_johns
+...
+```
+
+{% endraw %}
+
+## Next steps
+Congratulations! You know how to associate an Authorization Policy with Form Configuration. Now you can learn about associating an Authorization Policy with a page. 
+
+* [Associating an Authorization Policy with a Page](/get-started/authorization-policy/associating-authorization-policy-page)
+
+## Questions?
+
+We are always happy to help with any questions you may have. Consult our  [documentation](), [contact support](), or  [connect with our sales team](). 
+
+
+

--- a/marketplace_builder/pages/getting-started/authorization-policy/associating-authorization-policy-formconfiguration.liquid
+++ b/marketplace_builder/pages/getting-started/authorization-policy/associating-authorization-policy-formconfiguration.liquid
@@ -34,10 +34,7 @@ configuration:
     validation:
       presence: {}
 ---
-{% form url: "/api/users/{{ current_user.id }}" %}
-  {% input 'last_name', label: 'Last Name' %}
-  {% submit 'Save' %}
-{% endform %}
+...
 ```
 
 {% endraw %}


### PR DESCRIPTION
Associating an Authorization Policy with Form Configuration tutorial for the Get Started/Authorization Policy section. 