### PR TITLE
Create using-static-amp-template.liquid

### DIFF
--- a/marketplace_builder/views/pages/how-to/amp/using-static-amp-template.liquid
+++ b/marketplace_builder/views/pages/how-to/amp/using-static-amp-template.liquid
@@ -1,0 +1,58 @@
+---
+converter: markdown
+metadata:
+  title: Using a Static AMP Template 
+  description: This guide will help you use a static template (downloaded from the Internet as a zip file) on your Platform OS site.
+slug: how-to/amp/using-static-amp-template 
+searchable: true
+---
+
+This guide will help you use a static template (downloaded from the Internet as a zip file) on your Platform OS site. 
+The template featured in this tutorial is an [Accelerated Mobile Page (AMP)](https://www.ampproject.org/learn/overview/), so this tutorial can be used as the first step to building AMP pages on Platform OS. 
+
+## Requirements
+This is an advanced tutorial. To follow it, you should be familiar with basic Platform OS concepts, technologies, and the topics in the Get Started section, especially pages, layouts, and assets. 
+
+* [How Platform OS Works](/how-platformos-works)
+* [Get Started: Pages](/get-started/pages/pages)
+* [Get Started: Layouts](/get-started/pages/layouts)
+* [Get Started: Assets](/get-started/pages/assets)
+
+## Steps
+
+Using a static theme is a three-step process:
+
+1. Download template
+2. Put downloaded template into codebase
+3. Sync and check  
+
+### Step 1: Download template
+Download an AMP template from the Internet, e.g. from [AMP Start](https://www.ampstart.com/templates). This tutorial refers to the [Blog Template](https://www.ampstart.com/archive/blog.zip).
+
+Unzip the template. You see the template files organized into directories: `css` (page style), `img` (all images), and `template` (HTML AMP template). 
+
+### Step 2: Put downloaded template into codebase
+Copy all of the downloaded and unzipped directories and files into your `assets` directory, for example:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+cp -r ~/Downloads/blog/* marketplace_builder/assets
+</code></pre> 
+
+{% include "alert/note", content: "Consider compressing images. Images in templates are rarely optimized, so by optimizing them, you can accelerate your pages even more." %}
+
+### Step 3: Sync and check 
+Sync or deploy your Instance. Use the `asset_url` filter to list them and check that the files have been uploaded to our CDN. 
+
+Copy the URL of a file on the CDN and paste it into your browser to check it's there and working. If you load the html file from the CDN, you can see the (AMP) page. 
+
+## Next steps
+
+Congratulations! You can now use a static theme on your Platform OS Instance. To fully adapt it to Platform OS, convert the HTML to pages, layouts, and partials:
+
+* [Converting AMP HTML Pages to Layouts and pages](/ how-to/amp/converting-amp-html-layouts-pages)
+
+{% include 'shared/questions_section' %}
+
+
+ 
+


### PR DESCRIPTION
Using a Static AMP Theme tutorial for the How-To Guides/AMP section. 1/3 of AMP series. 