### PR TITLE
Create feeding-data-amp-pages-graphql.liquid

### DIFF
--- a/marketplace_builder/views/pages/how-to/amp/feeding-data-amp-pages-graphql.liquid
+++ b/marketplace_builder/views/pages/how-to/amp/feeding-data-amp-pages-graphql.liquid
@@ -143,16 +143,6 @@ query get_listings($slug: String) {
 custom_attributes:
 - name: price
   attribute_type: float
-  html_tag: input
-  input_html_options: {}
-  label: Price
-  public: true
-  search_in_query: false
-  searchable: false
-  validation:
-  - field_name: price
-    required: true
-    validation_only_on_update: false
 </code></pre>
 
 ### Step 3: Display product details

--- a/marketplace_builder/views/pages/how-to/amp/feeding-data-amp-pages-graphql.liquid
+++ b/marketplace_builder/views/pages/how-to/amp/feeding-data-amp-pages-graphql.liquid
@@ -1,0 +1,178 @@
+---
+converter: markdown
+metadata:
+  title: Feeding data into AMP Pages with GraphQL
+  description: This guide will help you feed data into your AMP pages using GraphQL. 
+slug: how-to/amp/feeding-data-amp-pages-graphql
+searchable: true
+---
+
+This guide will help you feed data into your AMP pages using GraphQL. The guide explains the process through a real-life example of displaying products of an online store.  
+
+## Requirements
+This is an advanced tutorial. To follow it, you should be familiar with basic Platform OS concepts, technologies, and the topics in the Get Started section, especially pages. You should also know what AMP pages are and how to create them.  
+
+* [How Platform OS Works](/how-platformos-works)
+* [Get Started: Pages](/get-started/pages/pages)
+* [Using a Static AMP Template](/how-to/amp/using-static-amp-template)
+* [Converting AMP HTML Pages to Layouts and Pages](/how-to/amp/converting-amp-html-layouts-pages)
+ 
+## Steps
+Feeding data into AMP pages with GraphQL, in this case, displaying products on a page is a four-step process:
+
+1. Display list of products 
+2. Create JSON endpoint
+3. Fetch listing data
+4. Display product details
+
+### Step 1: Display list of products
+
+Create the main page, HTML extended with AMP tags and objects `marketplace_builder/views/pages/product-list.liquid`:
+
+<pre><code class="language-liquid">
+---
+slug: product-list
+format: html
+layout_name: application
+---
+<!-- AMP dependencies -->
+<script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async=""></script>
+<script custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js" async=""></script>
+<script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async=""></script>
+..........
+  <amp-state id="products">
+    <script type="application/json">
+      {
+        "order": "desc"
+      }
+    </script>
+  </amp-state>
+
+  <select on="change: AMP.setState({products: {order: event.value}})">
+    <option value="desc">Price: High-Low</option>
+    <option value="asc">Price: Low-High</option>
+  </select>
+
+  <amp-list [src]="'api/products-' + products.order + '.json'" src="api/products-desc.json" layout="responsive">
+    <template type="amp-mustache">
+      <a href="/product-details/{% raw %}{{ slug }}{% endraw %}">
+        <div>
+          <amp-img src="{% raw %}{{image}}{% endraw %}" width="300" layout="responsive" noloading=""></amp-img>
+          <h2>{% raw %}{{name}}{% endraw %}</h2>
+          {% raw %}{{description}}{% endraw %}
+        </div>
+        <div>${% raw %}{{ price }}{% endraw %}</div>
+      </a>
+    </template>
+  </amp-list>
+</code></pre>
+
+#### Notes: 
+* This page declares the AMP state variable `products` with a JSON data structure format. 
+* `"order": "desc"` is the default sort order.
+* `<select>` changes the sort order stored in the state variable
+* The data source for `<amp-list>` is either `products-asc.json` or `products-desc.json` and is chosen based on the state variable `products.order`.
+* `amp-mustache` enables the 'mustache' (double curly braces) templating syntax.
+* The `{% raw %}` tag instructs the liquid preprocessor not to interpret the `{{}}` tags, and leaves them to AMP/mustache to process. 
+
+
+### Step 2: Create JSON endpoint 
+Create the JSON endpoint, a dynamically generated JSON document from which AMP fetches the data that it displays `mviews/pages/api/products-asc.json.liquid`: 
+
+<pre><code class="language-liquid">
+---
+slug: api/products
+format: json
+---
+{% query_graph 'get_listings', result_name: g %}
+{% assign results = g.listings.results | sort: 'price' %}
+
+{
+  "items": [
+{% for listing in results %}
+    {
+      "name": {{ listing.name | json }},
+      "slug": {{ listing.slug | json }},
+      "description": {{ listing.description | json }},
+      "image": {{ listing.photos[0].url | json }},
+      "price": {{ listing.price }}
+    }{% unless forloop.last %},{% endunless %}
+{% endfor %}
+  ]
+}
+</code></pre>
+
+#### Notes:
+* The GraphQL query is not given any argument, thus it retrieves all the listings (products) which are then sorted by price in ascending order with the `sort:` liquid filter.
+* Then the `for` loop populates the `"items"` list with JSON data that contains the info for each product.
+* The listing puts a comma after each element except for the last in the list. 
+
+### Step 3: Fetch listing data 
+Create the GraphQL query that fetches listing data `marketplace_builder/graph_queries/get_listings.graphql`:
+
+<pre><code class="language-graphql">
+query get_listings($slug: String) {
+  listings(
+    listing: {
+      is_deleted: false
+      slug: $slug
+    }
+  ) {
+    total_entries
+    results {
+      name
+      slug
+      description
+      photos { url }
+      price: property(name: "price")
+    }
+  }
+}
+</code></pre>
+
+#### Notes: 
+* If the optional slug argument is omitted, then it returns all listings.
+* `price` is a custom attribute defined in the Transactable Type's .yml file, which is found in the `transactable_types` directory:  
+
+<pre><code class="language-yaml">
+.....
+custom_attributes:
+- name: price
+  attribute_type: float
+  html_tag: input
+  input_html_options: {}
+  label: Price
+  public: true
+  search_in_query: false
+  searchable: false
+  validation:
+  - field_name: price
+    required: true
+    validation_only_on_update: false
+</code></pre>
+
+### Step 3: Display product details
+Create the `/product-details` page that loads when visitors click on a product from `/product-list` above `views/pages/product-details.liquid`:
+
+<pre><code class="language-liquid">
+---
+slug: product-details
+format: html
+layout_name: application
+---
+{% query_graph 'get_listings', result_name: g, slug: params.slug2 %}
+{% assign p = g.listings.results.first %}
+
+<h1>{{ p.name }}</h1>
+<amp-img src="{{ p.photos[0].url }}" layout="responsive"></amp-img>
+<div>${{ p.price }}</div>
+<div>{{ p.description }}</div>
+</code></pre>
+
+#### Notes: 
+* The page at `/product-list` passes the listing (product) slug to this page through the URL, which is formed as `/product-details/<listing_slug>`
+* Then we pass on the listing's slug to the GraphQL query (`slug: params.slug2`), to find the product details.
+* This is the same GraphQL query that you used in the other page to retrieve all listings, but this time you call it with the listing slug to find just one listing. 
+
+{% include 'shared/questions_section' %}
+

--- a/marketplace_builder/views/pages/how-to/amp/feeding-data-amp-pages-graphql.liquid
+++ b/marketplace_builder/views/pages/how-to/amp/feeding-data-amp-pages-graphql.liquid
@@ -30,6 +30,7 @@ Feeding data into AMP pages with GraphQL, in this case, displaying products on a
 Create the main page, HTML extended with AMP tags and objects `marketplace_builder/views/pages/product-list.liquid`:
 
 <pre><code class="language-liquid">
+{% raw %}
 ---
 slug: product-list
 format: html
@@ -65,6 +66,7 @@ layout_name: application
       </a>
     </template>
   </amp-list>
+{% endraw %}
 </code></pre>
 
 #### Notes: 
@@ -80,6 +82,7 @@ layout_name: application
 Create the JSON endpoint, a dynamically generated JSON document from which AMP fetches the data that it displays `mviews/pages/api/products-asc.json.liquid`: 
 
 <pre><code class="language-liquid">
+{% raw %}
 ---
 slug: api/products
 format: json
@@ -100,6 +103,7 @@ format: json
 {% endfor %}
   ]
 }
+{% endraw %}
 </code></pre>
 
 #### Notes:
@@ -155,6 +159,7 @@ custom_attributes:
 Create the `/product-details` page that loads when visitors click on a product from `/product-list` above `views/pages/product-details.liquid`:
 
 <pre><code class="language-liquid">
+{% raw %}
 ---
 slug: product-details
 format: html
@@ -167,6 +172,7 @@ layout_name: application
 <amp-img src="{{ p.photos[0].url }}" layout="responsive"></amp-img>
 <div>${{ p.price }}</div>
 <div>{{ p.description }}</div>
+{% endraw %}
 </code></pre>
 
 #### Notes: 

--- a/marketplace_builder/views/pages/how-to/amp/feeding-data-amp-pages-graphql.liquid
+++ b/marketplace_builder/views/pages/how-to/amp/feeding-data-amp-pages-graphql.liquid
@@ -1,7 +1,7 @@
 ---
 converter: markdown
 metadata:
-  title: Feeding data into AMP Pages with GraphQL
+  title: Feeding Data into AMP Pages with GraphQL
   description: This guide will help you feed data into your AMP pages using GraphQL. 
 slug: how-to/amp/feeding-data-amp-pages-graphql
 searchable: true

--- a/marketplace_builder/views/pages/how-to/amp/feeding-data-amp-pages-graphql.liquid
+++ b/marketplace_builder/views/pages/how-to/amp/feeding-data-amp-pages-graphql.liquid
@@ -37,24 +37,13 @@ format: html
 layout_name: application
 ---
 <!-- AMP dependencies -->
-<script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async=""></script>
-<script custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js" async=""></script>
-<script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async=""></script>
+{% content_for 'amp-dependencies' %}
+  <script custom-element="amp-list" src="https://cdn.ampproject.org/v0/amp-list-0.1.js" async=""></script>
+  <script custom-element="amp-bind" src="https://cdn.ampproject.org/v0/amp-bind-0.1.js" async=""></script>
+  <script custom-template="amp-mustache" src="https://cdn.ampproject.org/v0/amp-mustache-0.1.js" async=""></script>
+{% endcontent_for %}
 ..........
-  <amp-state id="products">
-    <script type="application/json">
-      {
-        "order": "desc"
-      }
-    </script>
-  </amp-state>
-
-  <select on="change: AMP.setState({products: {order: event.value}})">
-    <option value="desc">Price: High-Low</option>
-    <option value="asc">Price: Low-High</option>
-  </select>
-
-  <amp-list [src]="'api/products-' + products.order + '.json'" src="api/products-desc.json" layout="responsive">
+  <amp-list src="api/products.json" layout="responsive">
     <template type="amp-mustache">
       <a href="/product-details/{% raw %}{{ slug }}{% endraw %}">
         <div>
@@ -69,17 +58,24 @@ layout_name: application
 {% endraw %}
 </code></pre>
 
+Include the AMP dependencies in the layout file `marketplace_builder/views/layouts/application.liquid`:
+
+<pre><code class="language-liquid">
+{% raw %}
+..........
+  {% yield 'amp-dependencies' %}
+..........
+{% endraw %}
+</code></pre>
+
 #### Notes: 
-* This page declares the AMP state variable `products` with a JSON data structure format. 
-* `"order": "desc"` is the default sort order.
-* `<select>` changes the sort order stored in the state variable
-* The data source for `<amp-list>` is either `products-asc.json` or `products-desc.json` and is chosen based on the state variable `products.order`.
+* The data source for `<amp-list>` is `products.json`.
 * `amp-mustache` enables the 'mustache' (double curly braces) templating syntax.
 * The `{% raw %}` tag instructs the liquid preprocessor not to interpret the `{{}}` tags, and leaves them to AMP/mustache to process. 
 
 
 ### Step 2: Create JSON endpoint 
-Create the JSON endpoint, a dynamically generated JSON document from which AMP fetches the data that it displays `mviews/pages/api/products-asc.json.liquid`: 
+Create the JSON endpoint, a dynamically generated JSON document from which AMP fetches the data that it displays `marketplace_builder/views/pages/api/products.json.liquid`: 
 
 <pre><code class="language-liquid">
 {% raw %}
@@ -88,7 +84,7 @@ slug: api/products
 format: json
 ---
 {% query_graph 'get_listings', result_name: g %}
-{% assign results = g.listings.results | sort: 'price' %}
+{% assign results = g.listings.results %}
 
 {
   "items": [
@@ -109,7 +105,7 @@ format: json
 #### Notes:
 * The GraphQL query is not given any argument, thus it retrieves all the listings (products) which are then sorted by price in ascending order with the `sort:` liquid filter.
 * Then the `for` loop populates the `"items"` list with JSON data that contains the info for each product.
-* The listing puts a comma after each element except for the last in the list. 
+* The loop puts a comma after each element except for the last in the list. 
 
 ### Step 3: Fetch listing data 
 Create the GraphQL query that fetches listing data `marketplace_builder/graph_queries/get_listings.graphql`:


### PR DESCRIPTION
Feeding Data into AMP Pages with GraphQL tutorial for the How-To Guides/AMP section. 3/3 of AMP series. 