### PR TITLE
Remove extra `%}` causing issue

### DIFF
--- a/marketplace_builder/views/pages/how-to/qa/creating-marketplace-kit-logs.liquid
+++ b/marketplace_builder/views/pages/how-to/qa/creating-marketplace-kit-logs.liquid
@@ -34,7 +34,7 @@ slug: log-test
 
 {% log 'This is a message' %}
 {% log params %}
-{% log user.id, type: 'debug' %} %}
+{% log user.id, type: 'debug' %}
 ```
 
 #### Notes:


### PR DESCRIPTION
Extra tag was breaking code preview:

![screen shot 2018-08-13 at 10 55 52](https://user-images.githubusercontent.com/15265711/44025246-85356218-9ee7-11e8-8bf5-b96186ad9864.png)
