### PR TITLE
Change links order in /get-started/pages sidebar

### DIFF
--- a/marketplace_builder/views/partials/shared/_nav-links.liquid
+++ b/marketplace_builder/views/partials/shared/_nav-links.liquid
@@ -93,12 +93,12 @@
                   "name":"Layouts"
                },
                {
-                  "href":"/get-started/pages/creating-page",
-                  "name":"Creating a Page"
-               },
-               {
                   "href":"/get-started/pages/creating-layout",
                   "name":"Creating a Layout"
+               },
+               {
+                  "href":"/get-started/pages/creating-page",
+                  "name":"Creating a Page"
                },
                {
                   "href":"/get-started/pages/adding-new-page-custom-url",


### PR DESCRIPTION
This is current order of the sidebar:

```
Pages
Metadata
Layouts
Creating a Page
Creating a Layout
Adding a New Page at a Custom URL
Injecting Dynamic Content into a Layout
Reusing Code Across Multiple Pages
Defining Response Headers
Search by content

```
I get that `Pages`, `Metadata` and `Layouts` is just pages explaining new terms.
But then, you introduce steps, and on `Creating a Layout` page you have `Creating a Page` as a next step:

![screen shot 2018-09-14 at 12 15 24](https://user-images.githubusercontent.com/1313115/45544554-efb25300-b817-11e8-8738-e1494c0c40ca.png)


So imho `Creating a Layout` should come first on the sidebar