### PR TITLE
Use code with class css for css example in /get-started/assets/assets

### DIFF
--- a/marketplace_builder/views/pages/get-started/assets/assets.liquid
+++ b/marketplace_builder/views/pages/get-started/assets/assets.liquid
@@ -38,7 +38,10 @@ You can access assets through their relative path on the CDN, or with the `asset
 **Examples**
 
 Accessing an image from a CSS file located at `assets/styles/page.css`:
-`background: transparent url('../images/logo.svg') top center no-repeat;`
+
+```css
+background: transparent url('../images/logo.svg') top center no-repeat;
+```
 
 Accessing a Javascript file from a layout:
 


### PR DESCRIPTION
This would bring more uniform style for examples in assets:

![image](https://user-images.githubusercontent.com/1313115/45553611-b3412000-b834-11e8-9a08-94617ae2f309.png)

Current:

![image](https://user-images.githubusercontent.com/1313115/45553766-0a46f500-b835-11e8-8b3f-cfafbf49a63c.png)
