### PR TITLE
form.properties remove model

### DIFF
--- a/marketplace_builder/views/pages/get-started/customizations/building-contact-form-with-customization.liquid
+++ b/marketplace_builder/views/pages/get-started/customizations/building-contact-form-with-customization.liquid
@@ -313,10 +313,10 @@ delay: 0
 enabled: true
 from: info@example.com
 subject: Contact
-to: '{{ form.model.properties.email }}'
+to: '{{ form.properties.email }}'
 trigger_condition: true
 ---
-<h2>Hi {{ form.model.properties.name }}</h2>
+<h2>Hi {{ form.properties.name }}</h2>
 <p>Thank you for your request, we will contact you shortly!</p>
 {% endraw %}
 ```


### PR DESCRIPTION
Not sure what the model is here for but it works without and seem more consistent. Unless of course there is a good reason and then that is fine. If so why use model?