### PR TITLE
Add filters reference

### DIFF
--- a/marketplace_builder/views/pages/get-started/assets/using-static-assets-pages.liquid
+++ b/marketplace_builder/views/pages/get-started/assets/using-static-assets-pages.liquid
@@ -21,6 +21,8 @@ To follow the steps in this tutorial, you should be familiar with the required d
 
 ## Steps
 
+{% include 'alert/note', content: 'Below steps are using Liquid filters, to learn about Liquid filters click <a href="../../reference/liquid/liquid-filters">here</a>.' %}
+
 Using static assets on your pages is a four-step process:
 
 1.  Create assets directory and subdirectories

--- a/marketplace_builder/views/pages/reference/liquid/liquid-filters.liquid
+++ b/marketplace_builder/views/pages/reference/liquid/liquid-filters.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Liquid Filters
   description: Liquid filters are simple methods that modify the output of numbers, strings, variables and objects.
-slug: reference/liquid-filters/liquid-filters
+slug: reference/liquid/liquid-filters
 searchable: true
 ---
 

--- a/marketplace_builder/views/partials/shared/_nav-links.liquid
+++ b/marketplace_builder/views/partials/shared/_nav-links.liquid
@@ -638,6 +638,16 @@
                   "name":"Translations"
                }
             ]
+         },
+         {
+            "href":"/reference/liquid",
+            "name":"Liquid",
+            "children":[
+               {
+                  "href":"/reference/liquid/liquid-filters",
+                  "name":"Liquid Filters"
+               }
+            ]
          }
       ]
    },


### PR DESCRIPTION
So there is a liquid filters reference page, that's not in the sidebar:
![image](https://user-images.githubusercontent.com/1313115/46207434-a7bb2200-c327-11e8-81ca-e13886b3ee56.png)
I'm not sure if this is something needed, but I find this useful, and I've added the link to this page when liquid filters occur the first time in the get-started tutorial.