### PR TITLE
Fix rotation example

### DIFF
--- a/marketplace_builder/views/partials/generated/liquid_filters/filters.liquid
+++ b/marketplace_builder/views/partials/generated/liquid_filters/filters.liquid
@@ -1387,7 +1387,7 @@ parameter; [1,2,3,4] rotated by 2 gives [3,4,1,2]
 
 ```liquid
 {% assign numbers = "1,2,3" | split: "," %}
-{{ numbers | rotate }} => [3,2,1]
+{{ numbers | rotate }} => [3,1,2]
 ```
 
 


### PR DESCRIPTION
It should be `[3,1,2]` not `[3,2,1]` (I think!)