### PR TITLE
Fixed typos based on Grammarly check, 2nd batch.

### DIFF
--- a/marketplace_builder/views/pages/how-platformos-works/basic-building-blocks.liquid
+++ b/marketplace_builder/views/pages/how-platformos-works/basic-building-blocks.liquid
@@ -9,7 +9,7 @@ searchable: true
 
 ## Pages, layouts, and partials
 
-**Pages** are the the most essential components of our platform, that define content displayed at a given path. Each page is represented by a single file with a liquid extension.
+**Pages** are the most essential components of our platform, that define content displayed at a given path. Each page is represented by a single file with a liquid extension.
 
 **Layouts** are Liquid views that store code that would normally repeat on a lot of pages and is surrounding page content (e.g. header, footer). Without layouts, pages would share a lot of duplicated code, and changing anything would become a very time consuming and error prone process. You can create as many layouts as you need, and decide which page uses which layout.
 
@@ -19,13 +19,13 @@ searchable: true
 
 ## Form Configurations
 
-**Form Configurations** are the main tool for rendering forms, persisting data, and sending notifications (email/sms/api) in a secure and customizable way.
+**Form Configurations** are the main tool for rendering forms, persisting data, and sending notifications (email/SMS/API) in a secure and customizable way.
 
 They give you full control when defining:
 
 * which fields for a defined resource can be persisted
 * what authorization rules apply to be able to submit the form (i.e. if you want to edit a comment, you might want to specify that only the creator or the administrator is able to do it)
-* what should happen when the form is submitted successfully (i.e. without validation errors), e.g. send an email/sms notifications or API call to a third party system
+* what should happen when the form is submitted successfully (i.e. without validation errors), e.g. send an email/SMS notifications or API call to a third party system
 * where the user should be redirected
 
 On top of that, you can define callbacks (either synchronous or asynchronous) for further modifications to the system using GraphQL mutations. For example, you can define a signup form that creates User records, and if the user input is valid, also creates a few sample products for them, so that they don’t have to start from scratch.
@@ -36,7 +36,7 @@ On top of that, you can define callbacks (either synchronous or asynchronous) fo
 
 **Users** are accounts that any of your users can have. Users are identified by their unique email addresses.
 
-**User Profiles** are roles in the marketplace. Each User Profile can be associated with any number of Properties and Custom Model Types. All users are assigned a User Profile named Default. The difference between User Profile and Custom Model Type is that each user can have maximum one profile of a given name (but can have many different profiles), whereas they can have many custom models with the same name. From practical perspective, it is very simple to create `upsert` operation on UserProfile (i.e. create user profile, or if it exists, update it)
+**User Profiles** are roles in the marketplace. Each User Profile can be associated with any number of Properties and Custom Model Types. All users are assigned a User Profile named Default. The difference between User Profile and Custom Model Type is that each user can have maximum one profile of a given name (but can have many different profiles), whereas they can have many custom models with the same name. From a practical perspective, it is very simple to create `upsert` operation on UserProfile (i.e. create user profile, or if it exists, update it)
 
 [Learn how to create and manage Users and User Profiles in our Get Started guide](/tutorials/users/users)
 
@@ -66,7 +66,7 @@ Each policy is parsed using Liquid, and the system checks them in order of their
 
 ## Translations
 
-You can use platformOS to build sites in any language, and each site can have multiple language versions. **Translations** are yml files used for multilingual sites, but also used to define date formats, flash messages or system wide default error messages like "can't be blank".
+You can use platformOS to build sites in any language, and each site can have multiple language versions. **Translations** are yml files used for multilingual sites but also used to define date formats, flash messages or system-wide default error messages like "can't be blank".
 
 [Learn more about Translations in our Reference](/tutorials/translations/translations)
 

--- a/marketplace_builder/views/pages/how-platformos-works/glossary.liquid
+++ b/marketplace_builder/views/pages/how-platformos-works/glossary.liquid
@@ -9,7 +9,7 @@ searchable: true
 
 ## Assets
 
-Assets are files that can be served by an http web server without any backend/server processing. They are usually javascript, stylesheets, documents (html, pdf, doc), fonts, media (audio, video) etc. files.
+Assets are files that can be served by an HTTP web server without any backend/server processing. They are usually javascript, stylesheets, documents (HTML, pdf, doc), fonts, media (audio, video) etc. files.
 
 Learn more:
 
@@ -25,7 +25,7 @@ Learn more:
 
 ## Assets, Static Assets
 
-To upload a static asset into our Content Delivery Network (CDN), place your assets into the `marketplace_builder/assets/` directory. They will be propagated in the most efficient way for user that is currently accessing them.
+To upload a static asset into our Content Delivery Network (CDN), place your assets into the `marketplace_builder/assets/` directory. They will be propagated in the most efficient way for the user that is currently accessing them.
 
 Learn more:
 
@@ -92,7 +92,7 @@ Learn more:
 Custom Model Types have multiple use cases.
 Think of them as a custom DB table, which allows you to build highly customized features. Use them to group Properties, and allow the user to provide multiple values for each of them.
 
-For example you can build a table that will store a user's favorite books. Each book has an author, title and a number of pages. These three fields are Properties. That’s why you can use Custom Model Type to group Properties.
+For example, you can build a table that will store a user's favorite books. Each book has an author, title and a number of pages. These three fields are Properties. That’s why you can use Custom Model Type to group Properties.
 
 Now you can build a form that allows users to add multiple books attached to their user profile (using GraphQL).
 
@@ -125,7 +125,7 @@ Learn more:
 
 The triple dashes `---` you see in various places (e.g. Form Configurations) are called FrontMatter.
 
-They are used to define variables in a YML format. In our case you can use Liquid and GraphQL in them, and they resolve before those variables are interpreted by the server.
+They are used to define variables in a YML format. In our case, you can use Liquid and GraphQL in them, and they resolve before those variables are interpreted by the server.
 
 There are various implementations of FrontMatter, but they have one aspect in common: they parse YML embedded in a different file, and return configuration and content of that file. Configuration is between `---` & `---` and content is the rest of it.
 
@@ -154,7 +154,7 @@ Learn more:
 
 Layout is a special kind of Liquid view that stores code that would normally repeat on a lot of pages and is surrounding page content.
 
-Usual use case for layouts is storing html doctype, header, footer, javascripts.
+The usual use case for layouts is storing HTML doctype, header, footer, javascripts.
 
 Learn more:
 
@@ -162,7 +162,7 @@ Learn more:
 
 ## Liquid
 
-A template language used in platformOS to build dynamic pages, and to provide dynamic configuration (e.g. based on currently logged in user). Use Liquid to provide Authorization Policies for forms and pages, or to specify Notifications (email, sms, API call).
+A template language used in platformOS to build dynamic pages, and to provide dynamic configuration (e.g. based on currently logged in user). Use Liquid to provide Authorization Policies for forms and pages, or to specify Notifications (email, SMS, API call).
 
 If you are not familiar with Liquid, a good starting point to learn is their [Official Liquid Documentation](https://shopify.github.io/liquid/). We have added a lot of filters and tags to make your life easier.
 
@@ -186,7 +186,7 @@ Learn more:
 
 Node.js is a javascript runtime for servers based on Chrome's V8 engine. By itself, it allows developers to write and run javascript on the server.
 
-Currently Long Term Support version is 8.x, and we always recommend you to use newest LTS version of Node for both stability and security reasons.
+Currently, Long Term Support version is 8.x, and we always recommend you to use the newest LTS version of Node for both stability and security reasons.
 
 Learn more:
 
@@ -194,7 +194,7 @@ Learn more:
 
 ## Notifications
 
-Notifications are messages sent to marketplace users (including admins) when something happens. A message can be an email, sms or programmatic call to a 3rd party API.
+Notifications are messages sent to marketplace users (including admins) when something happens. A message can be an email, SMS or programmatic call to a 3rd party API.
 
 They can be delayed, you can use Liquid, GraphQL, and trigger conditions to decide if a Notification should be sent. It is a very powerful mechanism used for example to welcome your new users, and then follow up after they added their first item, or even if they have been inactive for some time.
 
@@ -264,7 +264,7 @@ Users of the Partner Portal are called Partners. Partners have the permissions t
 
 ## Push (deploy)
 
-Pushing code to an Instance means it will pack your marketplace_builder into a zip file and send it to the server. In the future only modified files will be compressed and pushed to the server.
+Pushing code to an Instance means it will pack your marketplace_builder into a zip file and send it to the server. In the future, only modified files will be compressed and pushed to the server.
 
 A special case of deploy is a deploy with a `--force` (or `-f`) flag. It means it will deploy changes and additionally it will remove all files from the server that are not present in the currently pushed version.
 
@@ -291,7 +291,7 @@ Transactable Types allow you to define Transactables in terms of what Properties
 
 ## Translations
 
-Translations are yml files used for multilingual sites, but also used to define date format, or flash messages.
+Translations are yml files used for multilingual sites but also used to define date format, or flash messages.
 
 Learn more:
 
@@ -328,7 +328,7 @@ Because `_contact-form.liquid` is a partial it can be used in multiple places, a
 
 ## YAML
 
-A human friendly data serialization standard used in platformOS for setting properties in configuration files.
+A human-friendly data serialization standard used in platformOS for setting properties in configuration files.
 
 Learn more:
 

--- a/marketplace_builder/views/pages/tutorials/partner-portal/assigning-billing-plan-instance.liquid
+++ b/marketplace_builder/views/pages/tutorials/partner-portal/assigning-billing-plan-instance.liquid
@@ -1,16 +1,16 @@
 ---
 converter: markdown
 metadata:
-  title: Assigning a Billing Plan to an Instance 
-  description: This guide will help you assign Billing Plans to your clients' Instances. 
+  title: Assigning a Billing Plan to an Instance
+  description: This guide will help you assign Billing Plans to your clients' Instances.
 slug: tutorials/partner-portal/assigning-billing-plan-instance
 searchable: true
 ---
 
-This guide will help you assign Billing Plans to your clients' Instances. In platformOS terms, your clients are your SubPartners, so you'll assign Billing Plans to your SubPartner's Instances. 
+This guide will help you assign Billing Plans to your clients' Instances. In platformOS terms, your clients are your SubPartners, so you'll assign Billing Plans to your SubPartner's Instances.
 
 ## Requirements
-To follow the steps in this tutorial, you have to have at least one Billing Plan created. 
+To follow the steps in this tutorial, you have to have at least one Billing Plan created.
 
 * [Creating a Billing Plan](/tutorials/partner-portal/creating-billing-plan)
 
@@ -18,20 +18,20 @@ To follow the steps in this tutorial, you have to have at least one Billing Plan
 
 Assigning a Billing Plan to an Instance is a two-step process:
 
-1. Locate SubPartner Instances 
+1. Locate SubPartner Instances
 2. Assign Billing Plan
 
 ### Step 1: Locate SubPartner Instances
 
-In the menu on the left, click on `Partners`, and select your own Partner. The information page of the Partner is displayed. 
-Here you have some information about Instances — your own and your SubPartners'. 
+In the menu on the left, click on `Partners`, and select your own Partner. The information page of the Partner is displayed.
+Here you have some information about Instances — your own and your SubPartners'.
 
-Under "SubPartners Instances", click on the link to the Instances. A table of Instances is displayed — these are Instances that your SubPartner has created. Check the row for each Instance and make sure to update all "Unbilled" Instances. 
+Under "SubPartners Instances", click on the link to the Instances. A table of Instances is displayed — these are Instances that your SubPartner has created. Check the row for each Instance and make sure to update all "Unbilled" Instances.
 
 ### Step 2: Assign Billing Plan
 
-To assign a Billing Plan to Instances that don't have one assigned yet, click the `Change` button next the Billing Plan. Production plans are only available to production Instances, while staging plans are only available to staging Instances. From the drop-down, select the Billing Plan you'd like to assign, and click on `Change Billing Plan`. 
+To assign a Billing Plan to Instances that don't have one assigned yet, click the `Change` button next to the Billing Plan. Production plans are only available to production Instances, while staging plans are only available to staging Instances. From the drop-down, select the Billing Plan you'd like to assign, and click on `Change Billing Plan`. 
 
-An "[Instance name] Billing Plan was successfully updated" message is displayed, and you can see in the table that the Billing Plan has changed. 
+An "[Instance name] Billing Plan was successfully updated" message is displayed, and you can see in the table that the Billing Plan has changed.
 
 {% include 'shared/questions_section' %}

--- a/marketplace_builder/views/pages/tutorials/partner-portal/finding-instances.liquid
+++ b/marketplace_builder/views/pages/tutorials/partner-portal/finding-instances.liquid
@@ -12,7 +12,7 @@ This guide will help you find an Instance on the Partner Portal.
 The guide shows two ways to find Instances:
 
 * Default: Search for an Instance using the Search field.
-* Inactive Instances: Sometimes you won't be able to find an Instance a few minutes after creating it. It happens when an Instance had been successfully created, but failed to be registered in the Partner Portal. These are called Inactive Instances.
+* Inactive Instances: Sometimes you won't be able to find an Instance a few minutes after creating it. It happens when an Instance had been successfully created but failed to be registered in the Partner Portal. These are called Inactive Instances.
 
 ## Requirements
 To follow the steps in this tutorial, you should be able to log in to the Partner Portal, and have an Instance you created or have access to.
@@ -35,7 +35,7 @@ In the menu on the left, click on `Instances`. You can see a list of all Instanc
 * Partner the Instance belongs to
 * URL
 * Endpoint
-* Domain 
+* Domain
 
 The list of Instances changes dynamically to show the Instances that contain the string you typed.
 
@@ -53,7 +53,3 @@ Congratulations! You know how to find an Instance. Now you can learn about updat
 * [Updating an Instance](/tutorials/partner-portal/updating-instance)
 
 {% include 'shared/questions_section' %}
-
-
-
-

--- a/marketplace_builder/views/pages/tutorials/partner-portal/managing-integrations.liquid
+++ b/marketplace_builder/views/pages/tutorials/partner-portal/managing-integrations.liquid
@@ -9,7 +9,7 @@ This guide will help you set up and manage integrations with third-party service
 
 platformOS can be used with built-in third-party services that we set up, but you can also build your own connection to any external API.
 
-Currently we support the following integrations:
+Currently, we support the following integrations:
 
 * Social (OAuth)
     * Facebook
@@ -61,7 +61,3 @@ Congratulations! You know how to set up and manage integrations. Now you can lea
 * [Downloading the Codebase of an Instance](/tutorials/partner-portal/downloading-codebase-instance)
 
 {% include 'shared/questions_section' %}
-
-
-
-


### PR DESCRIPTION
Issue #327  
I checked another batch of docs by using Grammarly (you can find the list of checked pieces below) and make some changes based on the suggestions.

I reviewed the following topics:

**How platform.OS works**:
* Basic building blocks
* Glossary

**Tutorials**:
* Partner portal
    * Assigning a Billing Plan to an Instance
    * Changing the Partner of an Instance
    * Changing the Partner of a User
    * Checking the Releases of an Instance
    * Configuring a Test Email
    * Configuring www as the Default Domain
    * Creating a Billing Plan
    * Deleting an Instance
    * Deleting a User
    * Downloading the Codebase of an Instance
    * Finding Instances
    * Inviting a New User to the Partner Portal
    * Managing Integrations
    * Setting Up Instance and Partner Permissions for Users Outside of Your Own Partner
    * Setting Up a Production Domain
    * Setting Up a User's Instance Permissions
    * Setting Up a User's Partner Permissions
    * Unpublishing an Instance
    * Updating Instance Configuration
    * Updating an Instance
    * Updating a Partner