### PR TITLE
Make module ZIP creation clearer

### DIFF
--- a/marketplace_builder/views/pages/tutorials/modules/sharing-module.liquid
+++ b/marketplace_builder/views/pages/tutorials/modules/sharing-module.liquid
@@ -26,7 +26,7 @@ Sharing a module is a three-step process:
 
 ### Step 1: Create zip file
 
-Zip the files in `modules/MODULE_NAME` directory (including that folder).
+Go to `modules` directory and create a zip file with the contents of `MODULE_NAME` folder. It's important that the repository contains MODULE_NAME folder at it's top-level (and not modules/MODULE_NAME or contents of MODULE_NAME folder).
 
 ### Step 2: Upload module to the Module Marketplace
 

--- a/marketplace_builder/views/pages/tutorials/modules/sharing-module.liquid
+++ b/marketplace_builder/views/pages/tutorials/modules/sharing-module.liquid
@@ -26,7 +26,7 @@ Sharing a module is a three-step process:
 
 ### Step 1: Create zip file
 
-Go to `modules` directory and create a zip file with the contents of `MODULE_NAME` folder. It's important that the repository contains MODULE_NAME folder at it's top-level (and not modules/MODULE_NAME or contents of MODULE_NAME folder).
+Go to the `modules` directory and create a zip file with the contents of the `MODULE_NAME` folder. It's important that the repository contains the MODULE_NAME folder at its top level (and not modules/MODULE_NAME or contents of MODULE_NAME folder).
 
 ### Step 2: Upload module to the Module Marketplace
 


### PR DESCRIPTION
Some users reported that it's not clear what should be in ZIP archive that is uploaded as module version, this change should make it easier to figure out.