### PR TITLE
Remove closing </ul> (there was no opening <ul>)

### DIFF
--- a/marketplace_builder/views/pages/tutorials/customizations/building-contact-form-with-customization.liquid
+++ b/marketplace_builder/views/pages/tutorials/customizations/building-contact-form-with-customization.liquid
@@ -137,7 +137,6 @@ slug: contacts
   </tr>
   {% endfor %}
 </table>
-</ul>
 {% endraw %}
 ```
 


### PR DESCRIPTION
Second code sample in this section https://documentation.platformos.com/tutorials/customizations/building-contact-form-with-customization#step-4-render-customizations-within-page has closing `</ul>` but no opening `<ul>`