### PR TITLE
Organize tutorials menu navigation for PP

### DIFF
--- a/app/views/pages/get-started/creating-codebase.liquid
+++ b/app/views/pages/get-started/creating-codebase.liquid
@@ -12,7 +12,7 @@ This guide will help you create the codebase using the Marketplace Kit.
 In order to correctly communicate with the platformOS engine and API, your codebase should be organized into a specific directory structure. The root directory of your project should contain the `app` directory.
 
 {% capture content %}
-This guide explains how to create your codebase using the Marketplace Kit. Alternatively, you can create your directory structure by <a href="/tutorials/partner-portal/downloading-codebase-instance">Downloading the Codebase of an Instance</a> you created or have access to.
+This guide explains how to create your codebase using the Marketplace Kit. Alternatively, you can create your directory structure by <a href="/tutorials/partner-portal-instances/downloading-codebase-instance">Downloading the Codebase of an Instance</a> you created or have access to.
 {% endcapture %}
 {% include 'alert/tip', content: content %}
 

--- a/app/views/pages/release-notes/25-FEBRUARY-2019.liquid
+++ b/app/views/pages/release-notes/25-FEBRUARY-2019.liquid
@@ -16,7 +16,7 @@ searchable: true
 * **Search by ID for `admin_*` queries**: Added the possibility to search by ID for `admin_*` queries. Also, added metadata to all `admin_*` resources (possible to set them via GraphQL).
 * **User session timeout**: You can now change the duration of a user session to control when the user timeouts.
 
-{% include "alert/tutorial", content: "Follow our step-by-step tutorial to learn more about <a href='/tutorials/partner-portal/updating-instance-configuration'>Updating Instance Configuration and setting the duration of a user session</a>." %}
+{% include "alert/tutorial", content: "Follow our step-by-step tutorial to learn more about <a href='/tutorials/partner-portal-instances/updating-instance-configuration'>Updating Instance Configuration and setting the duration of a user session</a>." %}
 
 <h4 class="release-note release-note__improved">IMPROVED</h4>
 

--- a/app/views/pages/release-notes/billing-system-launch.liquid
+++ b/app/views/pages/release-notes/billing-system-launch.liquid
@@ -57,7 +57,7 @@ The platformOS team will:
 
 If you plan to resell Instances:
 
-- [Create your own Billing Plans](/tutorials/partner-portal/creating-billing-plan)
+- [Create your own Billing Plans](/tutorials/partner-portal-billing-plans/creating-billing-plan)
 - [Assign your Billing Plans](/tutorials/partner-portal/assigning-billing-plan-instance) to your clients' Instances
 
 {% capture content %}

--- a/app/views/pages/tutorials/notifications/creating-email-notification.liquid
+++ b/app/views/pages/tutorials/notifications/creating-email-notification.liquid
@@ -63,7 +63,7 @@ email_notifications:
 
 Now, when you submit the form, the newly registered user should receive the email.
 
-Please note: if you are working on a staging environment, you also need to [configure a test email](/tutorials/partner-portal/configuring-test-email), because we intercept all emails on staging to avoid spamming real users during tests.
+Please note: if you are working on a staging environment, you also need to [configure a test email](/tutorials/partner-portal-instances/configuring-test-email), because we intercept all emails on staging to avoid spamming real users during tests.
 
 ## Next steps
 

--- a/app/views/pages/tutorials/pages/custom-error-pages.liquid
+++ b/app/views/pages/tutorials/pages/custom-error-pages.liquid
@@ -33,12 +33,12 @@ The resource you were looking for does not exist.
 
 ## Error pages
 
-| Status Code 	| Name         	| Usage                                                                                                                                                                                                                                                                                     	|
+| Status Code   | Name          | Usage                                                                                                                                                                                                                                                                                       |
 |-------------	|--------------	|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------	|
-| 403         	| Forbidden    	| Solely used for a [violated Authorization Policy](/tutorials/authorization-policy/handling-violated-authorization-policy).                                                                                                                           	|
-| 404         	| Not Found    	| Rendered in multiple scenarios. Most commonly, it is rendered when you try to access or modify an object that does not exist. You can also set an Authorization Policy's `http_status` to 404 to force render this page instead of the default 403. 	|
-| 500         	| Server Error 	| If there is an error that cannot be handled gracefully, a server error page is displayed.                                                                                                                                                           	|
-| 503         	| Maintenance  	| You can [enable maintenance mode through the Partner Portal](/tutorials/partner-portal/updating-instance-configuration) (see `maintenance_mode` attribute).                                                                                        	|
+| 403           | Forbidden     | Solely used for a [violated Authorization Policy](/tutorials/authorization-policy/handling-violated-authorization-policy).                                                                                                                            |
+| 404           | Not Found     | Rendered in multiple scenarios. Most commonly, it is rendered when you try to access or modify an object that does not exist. You can also set an Authorization Policy's `http_status` to 404 to force render this page instead of the default 403.   |
+| 500           | Server Error  | If there is an error that cannot be handled gracefully, a server error page is displayed.                                                                                                                                                             |
+| 503           | Maintenance   | You can [enable maintenance mode through the Partner Portal](/tutorials/partner-portal-instances/updating-instance-configuration) (see `maintenance_mode` attribute).                                                                                         |
 
 
 ## Related topics

--- a/app/views/pages/tutorials/partner-portal/assigning-billing-plan-instance.liquid
+++ b/app/views/pages/tutorials/partner-portal/assigning-billing-plan-instance.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Assigning a Billing Plan to an Instance
   description: This guide will help you assign Billing Plans to your clients' Instances.
-slug: tutorials/partner-portal/assigning-billing-plan-instance
+slug: tutorials/partner-portal-billing-plans/assigning-billing-plan-instance
 searchable: true
 ---
 
@@ -12,7 +12,7 @@ This guide will help you assign Billing Plans to your clients' Instances. In pla
 ## Requirements
 To follow the steps in this tutorial, you have to have at least one Billing Plan created.
 
-* [Creating a Billing Plan](/tutorials/partner-portal/creating-billing-plan)
+* [Creating a Billing Plan](/tutorials/partner-portal-billing-plans/creating-billing-plan)
 
 ## Steps
 

--- a/app/views/pages/tutorials/partner-portal/changing-partner-instance.liquid
+++ b/app/views/pages/tutorials/partner-portal/changing-partner-instance.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Changing the Partner of an Instance
   description: This guide will help you change the Partner an Instance belongs to.
-slug: tutorials/partner-portal/changing-partner-instance
+slug: tutorials/partner-portal-instances/changing-partner-instance
 searchable: true
 ---
 
@@ -33,4 +33,4 @@ The Instance information page reloads, and you can see that the Instance now bel
 ## Next steps
 Congratulations! You have changed the Partner an Instance belongs to. Now you can update a Partner's information:
 
-* [Updating a Partner](/tutorials/partner-portal/updating-partner)
+* [Updating a Partner](/tutorials/partner-portal-users/updating-partner)

--- a/app/views/pages/tutorials/partner-portal/changing-partner-user.liquid
+++ b/app/views/pages/tutorials/partner-portal/changing-partner-user.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Changing the Partner of a User
   description: This guide will help you change the Partner that a User belongs to.
-slug: tutorials/partner-portal/changing-partner-user
+slug: tutorials/partner-portal-users/changing-partner-user
 searchable: true
 ---
 
@@ -13,7 +13,7 @@ This guide will help you change the Partner that a User belongs to.
 To follow the steps in this tutorial, you should be able to log in to the Partner Portal, have access to a User and multiple Partners.
 
 * [Accessing the Partner Portal](/get-started/accessing-partner-portal)
-* [Inviting a New User to the Partner Portal](/tutorials/partner-portal/inviting-new-user-to-partner-portal)
+* [Inviting a New User to the Partner Portal](/tutorials/partner-portal-users/inviting-new-user-to-partner-portal)
 
 ## Steps
 
@@ -34,4 +34,4 @@ An `[email address] Partner was successfully updated.` message is displayed and 
 ## Next steps
 Congratulations! You have changed the Partner a User belongs to. Now you can learn about updating a Partner's information:
 
-* [Updating a Partner](/tutorials/partner-portal/updating-partner)
+* [Updating a Partner](/tutorials/partner-portal-users/updating-partner)

--- a/app/views/pages/tutorials/partner-portal/checking-releases-instance.liquid
+++ b/app/views/pages/tutorials/partner-portal/checking-releases-instance.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Checking the Releases of an Instance
   description: This guide will help you check the releases of an Instance on the Partner Portal.
-slug: tutorials/partner-portal/checking-releases-instance
+slug: tutorials/partner-portal-instances/checking-releases-instance
 searchable: true
 ---
 
@@ -31,4 +31,4 @@ Click on the `Releases` button to display the list of releases for the Instance.
 ## Next steps
 Congratulations! You know how to check the releases of an Instance. Now you can download the codebase of a release:
 
-* [Downloading the Codebase of an Instance](/tutorials/partner-portal/downloading-codebase-instance)
+* [Downloading the Codebase of an Instance](/tutorials/partner-portal-instances/downloading-codebase-instance)

--- a/app/views/pages/tutorials/partner-portal/configuring-test-email.liquid
+++ b/app/views/pages/tutorials/partner-portal/configuring-test-email.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Configuring a Test Email
   description: This guide will help you configure a test email for your Instance through the Partner Portal.
-slug: tutorials/partner-portal/configuring-test-email
+slug: tutorials/partner-portal-instances/configuring-test-email
 searchable: true
 ---
 

--- a/app/views/pages/tutorials/partner-portal/configuring-www-default-domain.liquid
+++ b/app/views/pages/tutorials/partner-portal/configuring-www-default-domain.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Configuring www as the Default Domain
   description: This guide will help you set up the www version of your domain as the default domain.
-slug: tutorials/partner-portal/configuring-www-default-domain
+slug: tutorials/partner-portal-domains/configuring-www-default-domain
 searchable: true
 ---
 
@@ -13,7 +13,7 @@ This guide will help you set up the www version of your domain (www.example.com 
 To set up the www version of your domain as the default domain, you have to have access to the Partner Portal, and a production domain set up.
 
 * [Accessing the Partner Portal](/get-started/accessing-partner-portal)
-* [Setting Up a Production Domain](/tutorials/partner-portal/setting-up-production-domain)
+* [Setting Up a Production Domain](/tutorials/partner-portal-domains/setting-up-production-domain)
 
 ## Steps
 

--- a/app/views/pages/tutorials/partner-portal/creating-billing-plan.liquid
+++ b/app/views/pages/tutorials/partner-portal/creating-billing-plan.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Creating a Billing Plan
   description: This guide will help you create your own Billing Plan.
-slug: tutorials/partner-portal/creating-billing-plan
+slug: tutorials/partner-portal-billing-plans/creating-billing-plan
 searchable: true
 ---
 

--- a/app/views/pages/tutorials/partner-portal/deleting-instance.liquid
+++ b/app/views/pages/tutorials/partner-portal/deleting-instance.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Deleting an Instance
   description: This guide will help you delete an Instance.
-slug: tutorials/partner-portal/deleting-instance
+slug: tutorials/partner-portal-instances/deleting-instance
 searchable: true
 ---
 
@@ -14,7 +14,7 @@ This guide will help you delete an Instance. If you delete an Instance:
 * Instance data, like users and Customization will NOT be deleted, but won't be accessible in any way;
 * it will not be billable.
 
-{% include 'alert/warning', content: 'Be careful with deleting an Instance. A deleted Instance can only be partially recovered, and only by our customer support. You might want to consider <a href="/tutorials/partner-portal/unpublishing-instance">Unpublishing an Instance</a> instead.' %}
+{% include 'alert/warning', content: 'Be careful with deleting an Instance. A deleted Instance can only be partially recovered, and only by our customer support. You might want to consider <a href="/tutorials/partner-portal-instances/unpublishing-instance">Unpublishing an Instance</a> instead.' %}
 
 ## Requirements
 To follow the steps in this tutorial, you should be able to log in to the Partner Portal, and have an Instance you created or have access to.
@@ -32,7 +32,7 @@ Deleting an Instance is a two-step process:
 
 In the menu on the left, click on `Instances`, and select the Instance you would like to delete. The information page of the Instance is displayed.
 
-You can find more information on how to locate an Instance in our [Finding Instances](/tutorials/partner-portal/finding-instances) tutorial.
+You can find more information on how to locate an Instance in our [Finding Instances](/tutorials/partner-portal-instances/finding-instances) tutorial.
 
 ### Step 2: Delete Instance
 
@@ -43,4 +43,4 @@ When you refresh your Instance, you can not see its information page anymore, as
 ## Next steps
 Congratulations! You know how to delete an Instance. Now you can learn about setting up a production domain:
 
-* [Setting Up a Production Domain](/tutorials/partner-portal/setting-up-production-domain)
+* [Setting Up a Production Domain](/tutorials/partner-portal-domains/setting-up-production-domain)

--- a/app/views/pages/tutorials/partner-portal/deleting-ssl-certificate.liquid
+++ b/app/views/pages/tutorials/partner-portal/deleting-ssl-certificate.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Deleting an SSL Certificate
   description: This guide will help you delete a previously requested SSL Certificate.
-slug: tutorials/partner-portal/deleting-ssl-certificate
+slug: tutorials/partner-portal-domains/deleting-ssl-certificate
 searchable: true
 ---
 
@@ -13,7 +13,7 @@ This guide will help you delete a previously requested SSL Certificate in case y
 To follow the steps in this tutorial, you have to have access to the Partner Portal, and you should have a previously requested SSL Certificate (or started requesting the certificate but the process has timed out).
 
 * [Accessing the Partner Portal](/get-started/accessing-partner-portal)
-* [Setting Up a Production Domain — Step 3: Request SSL Certificate](/tutorials/partner-portal/setting-up-production-domain#step-3-request-ssl-certificate)
+* [Setting Up a Production Domain — Step 3: Request SSL Certificate](/tutorials/partner-portal-domains/setting-up-production-domain#step-3-request-ssl-certificate)
 
 ## Steps
 
@@ -22,7 +22,7 @@ Deleting an SSL Certificate is a two-step process:
 <div data-autosteps></div>
 
 ### Step 1: Locate SSL Certificate
-[Find the Instance](/tutorials/partner-portal/finding-instances) connected to the domain which SSL Certificate you would like to delete.
+[Find the Instance](/tutorials/partner-portal-instances/finding-instances) connected to the domain which SSL Certificate you would like to delete.
 
 On the Instance page, click on `Domains`. Locate the domain, and click on `details`.
 

--- a/app/views/pages/tutorials/partner-portal/deleting-user.liquid
+++ b/app/views/pages/tutorials/partner-portal/deleting-user.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Deleting a User
   description: This guide will help you delete a user on the Partner Portal.
-slug: tutorials/partner-portal/deleting-user
+slug: tutorials/partner-portal-users/deleting-user
 searchable: true
 ---
 This guide will help you delete a user on the Partner Portal.
@@ -12,7 +12,7 @@ This guide will help you delete a user on the Partner Portal.
 To be able to delete a user on the Partner Portal, you have to have access to the Partner Portal, and the user you would like delete.
 
 * [Accessing the Partner Portal](/get-started/accessing-partner-portal)
-* [Inviting a New User to the Partner Portal](/tutorials/partner-portal/inviting-new-user-to-partner-portal)
+* [Inviting a New User to the Partner Portal](/tutorials/partner-portal-users/inviting-new-user-to-partner-portal)
 
 ## Steps
 
@@ -31,4 +31,4 @@ The user was deleted, the message `User [email address of user] was successfully
 ## Next steps
 Congratulations! You know how to delete a user on the Partner Portal. Now you can learn about changing the Partner that a user belongs to:
 
-* [Changing the Partner of a User](/tutorials/partner-portal/changing-partner-user)
+* [Changing the Partner of a User](/tutorials/partner-portal-users/changing-partner-user)

--- a/app/views/pages/tutorials/partner-portal/downloading-codebase-instance.liquid
+++ b/app/views/pages/tutorials/partner-portal/downloading-codebase-instance.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Downloading the Codebase of an Instance
   description: This guide will help you download the codebase of your Instance.
-slug: tutorials/partner-portal/downloading-codebase-instance
+slug: tutorials/partner-portal-instances/downloading-codebase-instance
 searchable: true
 ---
 
@@ -12,7 +12,7 @@ This guide will help you download the codebase of your Instance.
 ## Requirements
 To follow the steps in this tutorial, you should know how to check the releases of an Instance on the Partner Portal:
 
-* [Checking the Releases of an Instance](/tutorials/partner-portal/checking-releases-instance)
+* [Checking the Releases of an Instance](/tutorials/partner-portal-instances/checking-releases-instance)
 
 ## Steps
 

--- a/app/views/pages/tutorials/partner-portal/finding-instances.liquid
+++ b/app/views/pages/tutorials/partner-portal/finding-instances.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Finding Instances
   description: This guide will help you find an Instance on the Partner Portal.
-slug: tutorials/partner-portal/finding-instances
+slug: tutorials/partner-portal-instances/finding-instances
 searchable: true
 ---
 
@@ -49,4 +49,4 @@ If you found the Instance in the Inactive Instances list, you can try to activat
 ## Next steps
 Congratulations! You know how to find an Instance. Now you can learn about updating an Instance:
 
-* [Updating an Instance](/tutorials/partner-portal/updating-instance)
+* [Updating an Instance](/tutorials/partner-portal-instances/updating-instance)

--- a/app/views/pages/tutorials/partner-portal/inviting-new-user-to-partner-portal.liquid
+++ b/app/views/pages/tutorials/partner-portal/inviting-new-user-to-partner-portal.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Inviting a New User to the Partner Portal
   description: This guide will help you invite a new user to the Partner Portal, so that the new user can create, manage and configure Instances, and create and manage the permissions of other Partners.
-slug: tutorials/partner-portal/inviting-new-user-to-partner-portal
+slug: tutorials/partner-portal-users/inviting-new-user-to-partner-portal
 searchable: true
 ---
 This guide will help you invite a new user to the Partner Portal, so that the new user &ndash; depending on the permissions you assign to them &ndash; can create, manage and configure Instances, and create and manage the permissions of other Partners.
@@ -44,4 +44,4 @@ Click `Invite User`. The user will receive an invitation email with instructions
 ## Next steps
 Congratulations! You have invited a new user to the Partner Portal. Now, you can set up the permissions of this new user.
 
-* [Setting Up a User's Partner Permissions](/tutorials/partner-portal/setting-up-users-partner-permissions)
+* [Setting Up a User's Partner Permissions](/tutorials/partner-portal-users/setting-up-users-partner-permissions)

--- a/app/views/pages/tutorials/partner-portal/managing-integrations.liquid
+++ b/app/views/pages/tutorials/partner-portal/managing-integrations.liquid
@@ -2,7 +2,7 @@
 converter: markdown
 metadata:
   title: Managing Integrations
-slug: tutorials/partner-portal/managing-integrations
+slug: tutorials/partner-portal-instances/managing-integrations
 ---
 
 This guide will help you set up and manage integrations with third-party services like social media or payment service providers.
@@ -57,4 +57,4 @@ For Stripe, you'll need `Test login` and `Test publishable key` for the test mod
 ## Next steps
 Congratulations! You know how to set up and manage integrations. Now you can learn about downloading the codebase of an Instance:
 
-* [Downloading the Codebase of an Instance](/tutorials/partner-portal/downloading-codebase-instance)
+* [Downloading the Codebase of an Instance](/tutorials/partner-portal-instances/downloading-codebase-instance)

--- a/app/views/pages/tutorials/partner-portal/setting-up-instance-partner-permissions-outside-own-partner.liquid
+++ b/app/views/pages/tutorials/partner-portal/setting-up-instance-partner-permissions-outside-own-partner.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Setting Up Instance and Partner Permissions for Users Outside of Your Own Partner
   description: This guide will help you give Instance and Partner permissions to users that don't belong to your Partner via email.
-slug: tutorials/partner-portal/setting-up-instance-partner-permissions-outside-own-partner
+slug: tutorials/partner-portal-users/setting-up-instance-partner-permissions-outside-own-partner
 searchable: true
 ---
 
@@ -18,8 +18,8 @@ Permissions include:
 To be able to set up permissions for users on the Partner Portal, you have to have access to the Partner Portal. The two other tutorials linked below describe the process of granting permissions to users that belong to the same Partner as you.
 
 * [Accessing the Partner Portal](/get-started/accessing-partner-portal)
-* [Setting Up a User's Instance Permissions](/tutorials/partner-portal/setting-up-users-instance-permissions)
-* [Setting Up a User's Partner Permissions](/tutorials/partner-portal/setting-up-users-partner-permissions)
+* [Setting Up a User's Instance Permissions](/tutorials/partner-portal-users/setting-up-users-instance-permissions)
+* [Setting Up a User's Partner Permissions](/tutorials/partner-portal-users/setting-up-users-partner-permissions)
 
 ## Steps
 
@@ -51,4 +51,4 @@ Once you've selected the permissions, click on `Grant permissions`.
 ## Next steps
 Congratulations! You have set up Instance and Partner permissions for a user outside of your own Partner. You can also learn about changing the Partner that a User belongs to:
 
-* [Changing the Partner of a User](/tutorials/partner-portal/changing-partner-user)
+* [Changing the Partner of a User](/tutorials/partner-portal-users/changing-partner-user)

--- a/app/views/pages/tutorials/partner-portal/setting-up-production-domain.liquid
+++ b/app/views/pages/tutorials/partner-portal/setting-up-production-domain.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Setting Up a Production Domain
   description: This guide will help you set up a production domain.
-slug: tutorials/partner-portal/setting-up-production-domain
+slug: tutorials/partner-portal-domains/setting-up-production-domain
 searchable: true
 ---
 

--- a/app/views/pages/tutorials/partner-portal/setting-up-users-instance-permissions.liquid
+++ b/app/views/pages/tutorials/partner-portal/setting-up-users-instance-permissions.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Setting Up a User's Instance Permissions
   description: This guide will help you give Instance permissions to users of the Partner Portal.
-slug: tutorials/partner-portal/setting-up-users-instance-permissions
+slug: tutorials/partner-portal-users/setting-up-users-instance-permissions
 searchable: true
 ---
 This guide will help you give Instance permissions to users of the Partner Portal. Permissions include:
@@ -15,7 +15,7 @@ This guide will help you give Instance permissions to users of the Partner Porta
 To be able to set up Instance permissions for users on the Partner Portal, you have to have access to the Partner Portal, and the users you would like to give permissions to.
 
 * [Accessing the Partner Portal](/get-started/accessing-partner-portal)
-* [Inviting a New User to the Partner Portal](/tutorials/partner-portal/inviting-new-user-to-partner-portal)
+* [Inviting a New User to the Partner Portal](/tutorials/partner-portal-users/inviting-new-user-to-partner-portal)
 
 ## Steps
 
@@ -49,4 +49,4 @@ You can check the user's permissions anytime under `This user has access to foll
 ## Next steps
 Congratulations! You have set up a user's Instance permissions on the Partner Portal. Now, you may want to set up Partner permissions.
 
-* [Setting Up a User's Partner Permissions](/tutorials/partner-portal/setting-up-users-partner-permissions)
+* [Setting Up a User's Partner Permissions](/tutorials/partner-portal-users/setting-up-users-partner-permissions)

--- a/app/views/pages/tutorials/partner-portal/setting-up-users-partner-permissions.liquid
+++ b/app/views/pages/tutorials/partner-portal/setting-up-users-partner-permissions.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Setting Up a User's Partner Permissions
   description: This guide will help you give Partner permissions to users of the Partner Portal.
-slug: tutorials/partner-portal/setting-up-users-partner-permissions
+slug: tutorials/partner-portal-users/setting-up-users-partner-permissions
 searchable: true
 ---
 This guide will help you give Partner permissions to users of the Partner Portal. Permissions include:
@@ -15,7 +15,7 @@ This guide will help you give Partner permissions to users of the Partner Portal
 To be able to set up Partner permissions for users on the Partner Portal, you have to have access to the Partner Portal, and the users you would like to give permissions to.
 
 * [Accessing the Partner Portal](/get-started/accessing-partner-portal)
-* [Inviting a New User to the Partner Portal](/tutorials/partner-portal/inviting-new-user-to-partner-portal)
+* [Inviting a New User to the Partner Portal](/tutorials/partner-portal-users/inviting-new-user-to-partner-portal)
 
 ## Steps
 
@@ -48,4 +48,4 @@ You can check the user's permissions anytime under `This user has access to foll
 ## Next steps
 Congratulations! You have set up a user's Partner permissions on the Partner Portal. Now, you may want to set up Instance permissions.
 
-* [Setting Up a User's Instance Permissions](/tutorials/partner-portal/setting-up-users-instance-permissions)
+* [Setting Up a User's Instance Permissions](/tutorials/partner-portal-users/setting-up-users-instance-permissions)

--- a/app/views/pages/tutorials/partner-portal/unpublishing-instance.liquid
+++ b/app/views/pages/tutorials/partner-portal/unpublishing-instance.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Unpublishing an Instance
   description: This guide will help you unpublish an Instance.
-slug: tutorials/partner-portal/unpublishing-instance
+slug: tutorials/partner-portal-instances/unpublishing-instance
 searchable: true
 ---
 
@@ -30,7 +30,7 @@ Unpublishing an Instance is a two-step process:
 
 In the menu on the left, click on `Instances`, and select the Instance you would like to unpublish. The information page of the Instance is displayed.
 
-You can find more information on how to locate an Instance in our [Finding Instances](/tutorials/partner-portal/finding-instances) tutorial.
+You can find more information on how to locate an Instance in our [Finding Instances](/tutorials/partner-portal-instances/finding-instances) tutorial.
 
 ### Step 2: Unpublish Instance
 

--- a/app/views/pages/tutorials/partner-portal/updating-instance-configuration.liquid
+++ b/app/views/pages/tutorials/partner-portal/updating-instance-configuration.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Updating Instance Configuration
   description: This guide will help you update the configuration on an Instance.
-slug: tutorials/partner-portal/updating-instance-configuration
+slug: tutorials/partner-portal-instances/updating-instance-configuration
 searchable: true
 ---
 
@@ -113,5 +113,5 @@ This setting lets you change the duration of a user session. If not set, the def
 ## Next steps
 Congratulations! You know how to update the configuration of an Instance. Now you can set up a test email or add integrations:
 
-* [Configuring a Test Email](/tutorials/partner-portal/configuring-test-email)
+* [Configuring a Test Email](/tutorials/partner-portal-instances/configuring-test-email)
 * [Managing Integrations](/tutorials/partner-portal/managing-integrations)

--- a/app/views/pages/tutorials/partner-portal/updating-instance.liquid
+++ b/app/views/pages/tutorials/partner-portal/updating-instance.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Updating an Instance
   description: This guide will help you update an Instance.
-slug: tutorials/partner-portal/updating-instance
+slug: tutorials/partner-portal-instances/updating-instance
 searchable: true
 ---
 
@@ -38,4 +38,4 @@ Click on `Update`. An `Instance was successfully updated.` message is displayed,
 ## Next steps
 Congratulations! You have updated an Instance. Now you can learn about updating the configuration of an Instance:
 
-* [Updating Instance Configuration](/tutorials/partner-portal/updating-instance-configuration)
+* [Updating Instance Configuration](/tutorials/partner-portal-instances/updating-instance-configuration)

--- a/app/views/pages/tutorials/partner-portal/updating-partner.liquid
+++ b/app/views/pages/tutorials/partner-portal/updating-partner.liquid
@@ -3,7 +3,7 @@ converter: markdown
 metadata:
   title: Updating a Partner
   description: This guide will help you update a Partner's information.
-slug: tutorials/partner-portal/updating-partner
+slug: tutorials/partner-portal-users/updating-partner
 searchable: true
 ---
 
@@ -37,4 +37,4 @@ Click on `Update`. A `Partner was successfully updated.` message is displayed, a
 ## Next steps
 Congratulations! You have updated a Partner's information. Now you can learn about updating an Instance:
 
-* [Updating an Instance](/tutorials/partner-portal/updating-instance)
+* [Updating an Instance](/tutorials/partner-portal-instances/updating-instance)

--- a/app/views/pages/tutorials/payments/integrating-stripe.liquid
+++ b/app/views/pages/tutorials/payments/integrating-stripe.liquid
@@ -10,11 +10,11 @@ searchable: true
 This guide will help you configure a Stripe payment gateway.
 
 ## Requirements
-To follow this tutorial, you should be familiar with the Payments Module, the Stripe Module, the Stripe API and the Stripe Dashboard. You also need to have access to the Partner Portal, and know how to install a module. 
+To follow this tutorial, you should be familiar with the Payments Module, the Stripe Module, the Stripe API and the Stripe Dashboard. You also need to have access to the Partner Portal, and know how to install a module.
 * [Payments Module](https://github.com/mdyd-dev/platformos-payments)
 * [Stripe Module](https://github.com/mdyd-dev/platformos-payments-stripe)
 * [Stripe API Keys](https://stripe.com/docs/keys)
-* [Updating Instance Configuration](/tutorials/partner-portal/updating-instance-configuration)
+* [Updating Instance Configuration](/tutorials/partner-portal-instances/updating-instance-configuration)
 * [Installing a Module](/tutorials/modules/installing-module)
 
 
@@ -31,9 +31,9 @@ Install the following free modules:
 * Payments
 * Stripe
 
-During the installation process, set up Stripe public and secret keys. 
+During the installation process, set up Stripe public and secret keys.
 
-Make sure that `enable_sms_and_api_workflow_alerts_on_staging` in your Instance configuration is set to true. 
+Make sure that `enable_sms_and_api_workflow_alerts_on_staging` in your Instance configuration is set to true.
 
 ### Step 2: Create minimal working payment example
 
@@ -119,4 +119,3 @@ List of examples:
 - Stripe Elements	- explains how to integrate [Stripe Element Components](https://stripe.com/docs/stripe-js/elements/quickstart) with the Payments Module
 - Saving Account - goes through all the details of [Stripe Connect](https://stripe.com/docs/connect) integration
 - Saving Customer - example of reusing saved customer credit cards for future payments
-

--- a/app/views/pages/tutorials/users/logging-out-authenticated-user.liquid
+++ b/app/views/pages/tutorials/users/logging-out-authenticated-user.liquid
@@ -56,7 +56,7 @@ slug: log-out
 {% endraw %}
 ```
 
-{% include 'alert/note', content: 'To set an expiration for user sessions, use the `"timeout_in_minutes":  0,` attribute in the Instance configuration settings JSON as described in the <a href="/tutorials/partner-portal/updating-instance-configuration">Updating Instance Configuration</a> tutorial. If you set the attribute to 15, for example, all users will get logged out automatically after 15 minutes of inactivity.' %}
+{% include 'alert/note', content: 'To set an expiration for user sessions, use the `"timeout_in_minutes":  0,` attribute in the Instance configuration settings JSON as described in the <a href="/tutorials/partner-portal-instances/updating-instance-configuration">Updating Instance Configuration</a> tutorial. If you set the attribute to 15, for example, all users will get logged out automatically after 15 minutes of inactivity.' %}
 
 ## Next steps
 Congratulations! You created a log out for authenticated users. Now you can learn about resetting a user's password:

--- a/app/views/pages/tutorials/users/signing-in-user-manually.liquid
+++ b/app/views/pages/tutorials/users/signing-in-user-manually.liquid
@@ -66,7 +66,7 @@ slug: sign-in
 {% endraw %}
 ```
 
-{% include 'alert/note', content: 'To set an expiration for user sessions, use the `"timeout_in_minutes":  0,` attribute in the Instance configuration settings JSON as described in the <a href="/tutorials/partner-portal/updating-instance-configuration">Updating Instance Configuration</a> tutorial. If you set the attribute to 15, for example, all users will get logged out automatically after 15 minutes of inactivity.' %}
+{% include 'alert/note', content: 'To set an expiration for user sessions, use the `"timeout_in_minutes":  0,` attribute in the Instance configuration settings JSON as described in the <a href="/tutorials/partner-portal-instances/updating-instance-configuration">Updating Instance Configuration</a> tutorial. If you set the attribute to 15, for example, all users will get logged out automatically after 15 minutes of inactivity.' %}
 
 ## Next steps
 Congratulations! You created a sign in page for users to sign in manually. Now you can learn about signing in a user automatically after sign up:

--- a/app/views/partials/shared/nav/tutorials.liquid
+++ b/app/views/partials/shared/nav/tutorials.liquid
@@ -246,41 +246,54 @@
 <li class="topic-group">
   <h3>PARTNER PORTAL</h3>
 </li>
-<li class="{% if cp contains '/tutorials/partner-portal' %}active{% endif %}"><a
-    href="/tutorials/partner-portal/inviting-new-user-to-partner-portal">Partner Portal</a>
+<li class="{% if cp contains '/tutorials/partner-portal-users' %}active{% endif %}">
+  <a href="/tutorials/partner-portal-users/inviting-new-user-to-partner-portal">Users</a>
   <ul class="submenu">
-    <li><a href="/tutorials/partner-portal/inviting-new-user-to-partner-portal">Inviting a New User to the Partner
-        Portal</a></li>
-    <li><a href="/tutorials/partner-portal/setting-up-users-partner-permissions">Setting Up a User's Partner
-        Permissions</a></li>
-    <li><a href="/tutorials/partner-portal/setting-up-users-instance-permissions">Setting Up a User's Instance
-        Permissions</a></li>
-    <li><a href="/tutorials/partner-portal/deleting-user">Deleting a User</a></li>
-    <li><a href="/tutorials/partner-portal/setting-up-instance-partner-permissions-outside-own-partner">Setting Up
-        Instance and Partner Permissions for Users Outside of Your Own Partner</a></li>
-    <li><a href="/tutorials/partner-portal/updating-partner">Updating a Partner</a></li>
-    <li><a href="/tutorials/partner-portal/changing-partner-user">Changing the Partner of a User</a></li>
-    <li><a href="/tutorials/partner-portal/finding-instances">Finding Instances</a></li>
-    <li><a href="/tutorials/partner-portal/changing-partner-instance">Changing the Partner of an Instance</a></li>
-    <li><a href="/tutorials/partner-portal/updating-instance">Updating an Instance</a></li>
-    <li><a href="/tutorials/partner-portal/updating-instance-configuration">Updating Instance Configuration</a></li>
-    <li><a href="/tutorials/partner-portal/checking-releases-instance">Checking the Releases of an Instance</a></li>
-    <li><a href="/tutorials/partner-portal/downloading-codebase-instance">Downloading the Codebase of an Instance</a>
+    <li>
+      <a href="/tutorials/partner-portal-users/inviting-new-user-to-partner-portal">
+        Inviting a New User to the Partner Portal
+      </a>
     </li>
-    <li><a href="/tutorials/partner-portal/unpublishing-instance">Unpublishing an Instance</a></li>
-    <li><a href="/tutorials/partner-portal/deleting-instance">Deleting an Instance</a></li>
-    <li><a href="/tutorials/partner-portal/setting-up-production-domain">Setting Up a Production Domain</a></li>
-    <li><a href="/tutorials/partner-portal/configuring-www-default-domain">Configuring www as the Default Domain</a>
+    <li><a href="/tutorials/partner-portal-users/setting-up-users-partner-permissions">Setting Up a User's Partner Permissions</a></li>
+    <li><a href="/tutorials/partner-portal-users/setting-up-users-instance-permissions">Setting Up a User's Instance Permissions</a></li>
+    <li><a href="/tutorials/partner-portal-users/deleting-user">Deleting a User</a></li>
+    <li>
+      <a href="/tutorials/partner-portal-users/setting-up-instance-partner-permissions-outside-own-partner">
+        Setting Up Instance and Partner Permissions for Users Outside of Your Own Partner
+      </a>
     </li>
-    <li><a href="/tutorials/partner-portal/deleting-ssl-certificate">Deleting an SSL Certificate</a></li>
-    <li><a href="/tutorials/partner-portal/configuring-test-email">Configuring a Test Email</a></li>
-    <li><a href="/tutorials/partner-portal/managing-integrations">Managing Integrations</a></li>
-    <li><a href="/tutorials/partner-portal/creating-billing-plan">Creating a Billing Plan</a></li>
-    <li><a href="/tutorials/partner-portal/assigning-billing-plan-instance">Assigning a Billing Plan to an
-        Instance</a></li>
+    <li><a href="/tutorials/partner-portal-users/updating-partner">Updating a Partner</a></li>
+    <li><a href="/tutorials/partner-portal-users/changing-partner-user">Changing the Partner of a User</a></li>
   </ul>
 </li>
-
+<li class="{% if cp contains '/tutorials/partner-portal-instances' %}active{% endif %}">
+  <a href="/tutorials/partner-portal-instances/finding-instances">Instances</a>
+  <ul class="submenu">
+    <li><a href="/tutorials/partner-portal-instances/finding-instances">Finding Instances</a></li>
+    <li><a href="/tutorials/partner-portal-instances/changing-partner-instance">Changing the Partner of an Instance</a></li>
+    <li><a href="/tutorials/partner-portal-instances/updating-instance">Updating an Instance</a></li>
+    <li><a href="/tutorials/partner-portal-instances/updating-instance-configuration">Updating Instance Configuration</a></li>
+    <li><a href="/tutorials/partner-portal-instances/checking-releases-instance">Checking the Releases of an Instance</a></li>
+    <li><a href="/tutorials/partner-portal-instances/downloading-codebase-instance">Downloading the Codebase of an Instance</a></li>
+    <li><a href="/tutorials/partner-portal-instances/unpublishing-instance">Unpublishing an Instance</a></li>
+    <li><a href="/tutorials/partner-portal-instances/configuring-test-email">Configuring a Test Email</a></li>
+  </ul>
+</li>
+<li class="{% if cp contains '/tutorials/partner-portal-domains' %}active{% endif %}">
+  <a href="/tutorials/partner-portal-domains/setting-up-production-domain">Domains</a>
+  <ul class="submenu">
+    <li><a href="/tutorials/partner-portal-domains/setting-up-production-domain">Setting Up a Production Domain</a></li>
+    <li><a href="/tutorials/partner-portal-domains/configuring-www-default-domain">Configuring www as the Default Domain</a></li>
+    <li><a href="/tutorials/partner-portal-domains/deleting-ssl-certificate">Deleting an SSL Certificate</a></li>
+  </ul>
+</li>
+<li class="{% if cp contains '/tutorials/partner-portal-billing-plans' %}active{% endif %}">
+  <a href="/tutorials/partner-portal-billing-plans/creating-billing-plan">Billing Plans</a>
+  <ul class="submenu">
+    <li><a href="/tutorials/partner-portal-billing-plans/creating-billing-plan">Creating a Billing Plan</a></li>
+    <li><a href="/tutorials/partner-portal-billing-plans/assigning-billing-plan-instance">Assigning a Billing Plan to an Instance</a></li>
+  </ul>
+</li>
 
 <li class="topic-group">
   <h3>BEST PRACTICES</h3>


### PR DESCRIPTION
I wanted to find docs for creating domain and use menu navigation. All tutorial were in one bag. I've categorized it.

@diana-lakatos under `Partner Portal => Instances` I would add duplicated article about creating an instance. 

Before:
![image](https://user-images.githubusercontent.com/96238/60873118-1f629980-a236-11e9-8a78-f498e7e5dfd6.png)

After:
![image](https://user-images.githubusercontent.com/96238/60873068-0e198d00-a236-11e9-8327-3518e17b966c.png)
