### PR TITLE
Adds License and Attributions page

### DIFF
--- a/app/views/pages/license.liquid
+++ b/app/views/pages/license.liquid
@@ -1,0 +1,46 @@
+---
+slug: license
+searchable: false
+converter: markdown
+layout_name: application
+metadata:
+  title: License and Attributions
+  description: Learn more about the open-source license of our documentation. 
+  questions: true
+  contributors: false
+  feedback: false
+---
+
+## License
+
+### Documentation 
+
+The **platformOS Documentation** is fully open-source, licensed under the terms of the [MIT license](http://www.opensource.org/licenses/mit-license.html): 
+
+_Copyright © 2018-2019 platformOS_ 
+
+_Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software._
+
+_THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE._
+
+You can find all source files for the platformOS Documentation site and content in our public [GitHub repository](https://github.com/mdyd-dev/nearme-documentation).
+
+
+### platformOS Core and SaaS 
+To learn more about the copyrights of the platformOS software, its components (e.g. pos-cli) and SaaS solution, please check out our [Terms of Use](https://www.platformos.com/terms-of-use), that includes information on the copyright, license, and intellectual property rights. 
+
+### platformOS Modules 
+platformOS Modules and associated documentation files in our Module Marketplace each have their own copyrights and licensing, so please check the license of the module you’re interested in. 
+
+## Attributions 
+We use the following open-source assets on the platformOS documentation site:
+
+* External link icon made by [Dave Gandy](https://www.flaticon.com/authors/dave-gandy) from [www.flaticon.com](https://www.flaticon.com) 
+* Search icon made  by [Google](https://www.flaticon.com/authors/google) from [www.flaticon.com](https://www.flaticon.com)
+* Right arrow icon made by [Freepik](https://www.flaticon.com/authors/freepik) from [www.flaticon.com](https://www.flaticon.com)
+
+
+
+
+

--- a/app/views/partials/layouts/footer.liquid
+++ b/app/views/partials/layouts/footer.liquid
@@ -81,9 +81,9 @@
 				<div class="col-md-6">
 					<ul>
 						<li>Copyright &copy; platformOS 2019</li>
-						{% comment %} <li>
-							<a href="/terms-and-conditions">Terms &amp; Conditions</a>
-						</li> {% endcomment %}
+						<li>
+							<a href="/license">License and Attributions</a>
+						</li> 
 					</ul>
 				</div>
 			</div>


### PR DESCRIPTION
I added:
- License page (reviewed by Colin)
- link to footer next to copyright (I didin't link it on the copyright, because it wasn't self-explanatory that you'd fine this information there)

See on staging: https://diana-documentation.staging.oregon.platform-os.com/license

Closes #651 