### PR TITLE
Navigation: attach glossary to the main topic

### DIFF
--- a/app/views/partials/shared/nav/api-reference.liquid
+++ b/app/views/partials/shared/nav/api-reference.liquid
@@ -27,9 +27,10 @@
 </li>
 
 <li class="{% if cp contains '/api-reference/graphql' %}active{% endif %}">
-  <a href="/api-reference/graphql/queries">GraphQL API</a>
+  <a href="/api-reference/graphql/glossary">GraphQL API</a>
 
   <ul class="submenu">
+    {% include "shared/nav/link", href: "/api-reference/graphql/glossary", text: "Glossary" %}
     {% include "shared/nav/link", href: "/api-reference/graphql/queries", text: "Queries" %}
     {% include "shared/nav/link", href: "/api-reference/graphql/mutations", text: "Mutations" %}
     {% include "shared/nav/link", href: "/api-reference/graphql/objects", text: "Objects" %}
@@ -37,6 +38,5 @@
     {% include "shared/nav/link", href: "/api-reference/graphql/interfaces", text: "Interfaces" %}
     {% include "shared/nav/link", href: "/api-reference/graphql/enums", text: "Enums" %}
     {% include "shared/nav/link", href: "/api-reference/graphql/inputs", text: "Input Objects" %}
-    {% include "shared/nav/link", href: "/api-reference/graphql/glossary", text: "Glossary" %}
   </ul>
 </li>


### PR DESCRIPTION
I think we should have to introduction page for graphql api section. Glossary looks like a good candidate for this.