### PR TITLE
Translations: date formats

### DIFF
--- a/app/views/pages/tutorials/translations/date-format.liquid
+++ b/app/views/pages/tutorials/translations/date-format.liquid
@@ -1,0 +1,93 @@
+---
+converter: markdown
+metadata:
+  title: Date Format
+  description: Define you own date/time format for application
+slug: tutorials/translations/date-format
+searchable: true
+---
+
+## Date Format
+
+To render date/time in given format consistently accross the application use [`localize` (`l`)](https://documentation.platformos.com/api-reference/liquid/platformos-filters#localize-aliases-l) filter.
+{% raw %}
+```liquid
+  {{ user.created_at | localize: 'short' }} => 11:45
+```
+{% endraw %}
+
+In order to customize predefined formats you can overwrite them in translation
+file(ex. `app/translations/en.yml`).
+
+
+For example format `short` is defined with `short: '%-H:%M'` and format time to
+`11:45`. The `%H` and `%M` are format directives. They are standard date
+formatting for UNIX. You can see available
+directives for time and date [here](https://devhints.io/strftime)
+
+Here are default values for `en` localization, you can set different formats
+for time and date.
+
+
+```yml
+en:
+  time:
+    formats:
+      short: '%-H:%M'
+      long: '%a, %m/%d/%Y %H:%M'
+      with_time_zone: '%m/%d/%Y %H:%M (%Z)'
+      short_with_time_zone: '%-H:%M (%Z)'
+      day_and_month: '%b %d'
+      day_month_year: '%d-%m-%Y'
+
+  date:
+    abbr_months:
+      jan: Jan
+      feb: Feb
+      mar: Mar
+      apr: Apr
+      may: May
+      jun: Jun
+      jul: Jul
+      aug: Aug
+      sep: Sep
+      oct: Oct
+      nov: Nov
+      dec: Dec
+    months:
+      jan: January
+      feb: February
+      mar: March
+      apr: April
+      may: May
+      jun: June
+      jul: July
+      aug: August
+      sep: September
+      oct: October
+      nov: November
+      dec: December
+    abbr_days:
+      sun: Sun
+      mon: Mon
+      tue: Tue
+      wed: Wed
+      thu: Thu
+      fri: Fri
+      sat: Sat
+    days:
+      sun: Sunday
+      mon: Monday
+      tue: Tuesday
+      wed: Wednesday
+      thu: Thursday
+      fri: Friday
+      sat: Saturday
+    yesterday: Yesterday
+    formats:
+      long: '%B %d, %Y'
+      short: '%m/%d/%Y'
+      day_and_month: '%b %d'
+      day_month_year: '%d-%m-%Y'
+      stripe: '%m-%d-%Y'
+```

--- a/app/views/pages/tutorials/translations/date-format.liquid
+++ b/app/views/pages/tutorials/translations/date-format.liquid
@@ -2,30 +2,30 @@
 converter: markdown
 metadata:
   title: Date Format
-  description: Define you own date/time format for application
+  description: Defining your own date/time format for your application. 
 slug: tutorials/translations/date-format
 searchable: true
 ---
 
 ## Date Format
 
-To render date/time in given format consistently accross the application use [`localize` (`l`)](/api-reference/liquid/platformos-filters#localize-aliases-l) filter.
+To render date/time in a given format consistently accross the application use the [`localize` (`l`)](/api-reference/liquid/platformos-filters#localize-aliases-l) filter.
 {% raw %}
 ```liquid
   {{ user.created_at | localize: 'short' }} => 11:45
 ```
 {% endraw %}
 
-In order to customize predefined formats you can overwrite them in translation
-file (ex. `app/translations/en.yml`).
+In order to customize predefined formats you can overwrite them in the translation
+file (e.g. `app/translations/en.yml`).
 
 
-For example format `short` is defined with `short: '%-H:%M'` and format time to
+For example, use the format `short` defined with `short: '%-H:%M'` and format time to
 `11:45`. The `%H` and `%M` are format directives. They are standard date
 formatting for UNIX. You can see available
 directives for time and date [here](https://devhints.io/strftime)
 
-Here are default values for `en` localization, you can set different formats
+Here are default values for the `en` localization, you can set different formats
 for time and date.
 
 

--- a/app/views/pages/tutorials/translations/date-format.liquid
+++ b/app/views/pages/tutorials/translations/date-format.liquid
@@ -9,7 +9,7 @@ searchable: true
 
 ## Date Format
 
-To render date/time in given format consistently accross the application use [`localize` (`l`)](https://documentation.platformos.com/api-reference/liquid/platformos-filters#localize-aliases-l) filter.
+To render date/time in given format consistently accross the application use [`localize` (`l`)](/api-reference/liquid/platformos-filters#localize-aliases-l) filter.
 {% raw %}
 ```liquid
   {{ user.created_at | localize: 'short' }} => 11:45
@@ -17,7 +17,7 @@ To render date/time in given format consistently accross the application use [`l
 {% endraw %}
 
 In order to customize predefined formats you can overwrite them in translation
-file(ex. `app/translations/en.yml`).
+file (ex. `app/translations/en.yml`).
 
 
 For example format `short` is defined with `short: '%-H:%M'` and format time to
@@ -39,7 +39,6 @@ en:
       short_with_time_zone: '%-H:%M (%Z)'
       day_and_month: '%b %d'
       day_month_year: '%d-%m-%Y'
-
   date:
     abbr_months:
       jan: Jan

--- a/app/views/pages/tutorials/translations/translations.liquid
+++ b/app/views/pages/tutorials/translations/translations.liquid
@@ -11,6 +11,6 @@ searchable: true
 
 * [Multi-Language sites](/tutorials/translations/multilanguage-page): Manually translate your website and provide static copy in more than one language. You can create a `yml` file that maps the translation key to a value for each language, and then use the `t` (short for `translate`) filter in Liquid to render the proper value, based on the current user’s language.
 
-* Date Format: Come up with a common format for a date, then use the `l` (short for `localize`) filter to render date and time consistently across the platform. This is useful to be able to easily change the way date/time is displayed everywhere, or to customize on a per site basis.
+* [Date Format](/tutorials/translations/date-format): Come up with a common format for a date, then use the `l` (short for `localize`) filter to render date and time consistently across the platform. This is useful to be able to easily change the way date/time is displayed everywhere, or to customize on a per site basis.
 
 * [Flash messages](/tutorials/translations/system-messages): Define system messages returned by our [API](/api-reference/rest-api).

--- a/app/views/partials/shared/nav/tutorials.liquid
+++ b/app/views/partials/shared/nav/tutorials.liquid
@@ -38,6 +38,7 @@
     {% include "shared/nav/link", href: "/tutorials/translations/translations", text: "Translations" %}
     {% include "shared/nav/link", href: "/tutorials/translations/multilanguage-page", text: "Multi-Language Page" %}
     {% include "shared/nav/link", href: "/tutorials/translations/system-messages", text: "System Messages" %}
+    {% include "shared/nav/link", href: "/tutorials/translations/date-formats", text: "Date Formats" %}
   </ul>
 </li>
 


### PR DESCRIPTION
Describes how to set default date/time formats that can be used with `localize` filter.