### PR TITLE
Rename model to related_model

### DIFF
--- a/app/views/pages/tutorials/models/loading-related-models.liquid
+++ b/app/views/pages/tutorials/models/loading-related-models.liquid
@@ -156,10 +156,10 @@ The results show that this approach produces slow output. The n+1 queries slow d
 
 ### Step 4: Request data from related model within GraphQL query (recommended)
 
-To avoid n+1 queries, request company data within the `programmers` GraphQL query. Load related data at once along with the programmer collection using new GraphQL field called `model`.
+To avoid n+1 queries, request company data within the `programmers` GraphQL query. Load related data at once along with the programmer collection using new GraphQL field called `related_model`.
 
 ```graphql
-model(join_on_property: "company_id") { properties }
+related_model(join_on_property: "company_id") { properties }
 ```
 
 `join_on_property` argument is required and is used as a foreign key of the company collection. In SQL language this could look similarly:
@@ -176,7 +176,7 @@ programmers: models(filter: { name: { value: "programmer" } }, per_page: 200) {
     total_entries
     results {
       properties
-      company: model(model_name: "company", join_on_property: "company_id") {
+      company: related_model(model_name: "company", join_on_property: "company_id") {
         url: property(name: "url")
         properties
       }

--- a/app/views/pages/use-cases/e-commerce/creating-product-management-forms.liquid
+++ b/app/views/pages/use-cases/e-commerce/creating-product-management-forms.liquid
@@ -663,10 +663,10 @@ query get_products($id: ID) {
       name: property(name: "name")
       description: property(name: "description")
       price: property(name: "price")
-      brand: model(join_on_property: "brand_id") {
+      brand: related_model(join_on_property: "brand_id") {
         name: property(name: "name")
       }
-      product_type: model(join_on_property: "product_type_id") {
+      product_type: related_model(join_on_property: "product_type_id") {
         name: property(name: "name")
       }
     }
@@ -676,7 +676,7 @@ query get_products($id: ID) {
 
 Initially, the query will have only one parameter `$id`, but in the next topics you’ll extend it with different filters to implement filtering, pagination, etc.
 
-{% include 'alert/note', content: '`model(join_on_property: "propname")` is a useful method for [loading data from related models](/tutorials/models/loading-related-models)' %}
+{% include 'alert/note', content: '`related_model(join_on_property: "propname")` is a useful method for [loading data from related models](/tutorials/models/loading-related-models)' %}
 
 ### Step 6: Create products listing page
 


### PR DESCRIPTION
Changes after deprecating `model` and `models` in favour of `related_model` and `related_models`