### PR TITLE
Update queries.liquid

### DIFF
--- a/app/views/pages/api-reference/graphql/queries.liquid
+++ b/app/views/pages/api-reference/graphql/queries.liquid
@@ -7,6 +7,7 @@ metadata:
   contributors: false
   toc: true
 ---
+{% include 'alert/warning', content: 'Please note that <code>admin_*</code> queries will not return anything from a private folder in a module.' %}
 
 {% assign key = context.params.slug3 | append: context.version %}
 


### PR DESCRIPTION
Fixes #777 

Although it would be best to add the warning right before the admin_* queries, I could only add it in the beginning because of the auto-generated content. I think this is fine for now. 

It looks like this: https://diana-documentation.staging.oregon.platform-os.com/api-reference/graphql/queries

