### PR TITLE
Removed info on `{{ object }}`  in authorization policy

### DIFF
--- a/app/views/pages/tutorials/authorization-policy/authorization-policy.liquid
+++ b/app/views/pages/tutorials/authorization-policy/authorization-policy.liquid
@@ -13,15 +13,6 @@ Each policy is parsed using Liquid, and the system checks them in order of their
 
 If the content of the policy evaluates to anything other than `true`, the policy is considered violated and the system will not proceed with executing action (like submitting a form or rendering a page).
 
-## Contextual `object`
-
-Apart from pulling data from GraphQL you also have access to a variable called `object` (be careful not to override it).
-
-Depending on where the Authorization Policy is called from, this object contains:
-
-* `form` object in Form context
-* `page` object in page context
-
 ## Related topics
 
 * [Adding an Authorization Policy](/tutorials/authorization-policy/adding-authorization-policy)


### PR DESCRIPTION
It seems invalid. @Slashek you might need to confirm and approve or reject this PR