### PR TITLE
Update Digital Fuel URL - Broken Link

### DIFF
--- a/app/views/pages/use-cases/twilio-video-integration.liquid
+++ b/app/views/pages/use-cases/twilio-video-integration.liquid
@@ -320,4 +320,4 @@ For this, Twilio requires `identity` and `token` in JSON format.
 ## Author information
 
 **Daniel Telfer**
-Frontend Developer, [Digital Fuel](https://digitalfuel.nz)
+Frontend Developer, [Digital Fuel](http://digitalfuel.nz)


### PR DESCRIPTION
Should not have been https as does not have ssl.