### PR TITLE
Update api-reference.liquid

### DIFF
--- a/app/views/partials/shared/nav/api-reference.liquid
+++ b/app/views/partials/shared/nav/api-reference.liquid
@@ -32,12 +32,8 @@
 
   <ul class="submenu">
     {% include "shared/nav/link", href: "/api-reference/graphql/glossary", text: "Glossary" %}
-    {% include "shared/nav/link", href: "/api-reference/graphql/queries", text: "Queries" %}
-    {% include "shared/nav/link", href: "/api-reference/graphql/mutations", text: "Mutations" %}
-    {% include "shared/nav/link", href: "/api-reference/graphql/objects", text: "Objects" %}
-    {% include "shared/nav/link", href: "/api-reference/graphql/scalars", text: "Scalars" %}
-    {% include "shared/nav/link", href: "/api-reference/graphql/interfaces", text: "Interfaces" %}
-    {% include "shared/nav/link", href: "/api-reference/graphql/enums", text: "Enums" %}
-    {% include "shared/nav/link", href: "/api-reference/graphql/inputs", text: "Input Objects" %}
+    {% include "shared/nav/link", href: "/api-reference/graphql/rootquery.html", text: "Queries" %}
+    {% include "shared/nav/link", href: "/api-reference/graphql/rootmutation.html", text: "Mutations" %}
+    {% include "shared/nav/link", href: "/api-reference/graphql/activitystreamspayload.html", text: "Types" %} 
   </ul>
 </li>


### PR DESCRIPTION
Adds links to new GraphQL API Reference to the left navigation. 

