### PR TITLE
Liquid topics SEO update

### DIFF
--- a/app/views/pages/api-reference.liquid
+++ b/app/views/pages/api-reference.liquid
@@ -7,19 +7,28 @@ converter: markdown
 
 This section provides API Reference Documentation for the APIs you'll use when developing on platformOS.
 
-### Complete Guide to Liquid Markup
+## Complete Guide to Liquid Markup
 
-**Liquid** is a template language used in platformOS to build dynamic pages, and to provide dynamic configuration. We have added platformOS-specific filters and tags to make your life easier. Our complete guide to Liquid markup includes:
+**Liquid** (or Liquid markup) is a template language used in platformOS to build dynamic pages, and to provide dynamic configuration.  
 
-* Introduction
-* Types
-* Tags
-* Filters
-* Whitespace control
-* Detailed descriptions of platformOS-specific filters and tags
+Inspired by the official documentation, we divided our Liquid documentation into multiple parts for easy access, keeping it logical for newcomers. We start with an introduction, then describe types, tags grouped into three larger sections (variables, flow control, and loops), filters, objects, and whitespace control. 
+
+We have added platformOS-specific filters and tags that you can use when developing on platformOS. You should start learning about these when you’re comfortable with Liquid in general. We added a lot of custom filters and tags that make dealing with Liquid, dates, JSON, data structures, encoding, or URL templates easier. platformOS gives you the power to improve your code by exposing the Liquid profiler and giving you a filter that measures the execution time of any given block with a 1ms granularity. 
+
+Our complete guide to Liquid markup includes:
+
+* [Introduction](/api-reference/liquid/introduction)
+* [Types](/api-reference/liquid/types)
+* [Tags](/api-reference/liquid/platformos-tags) (including platformOS-specific tags)
+* [Filters](/api-reference/liquid/platformos-filters) (including platformOS-specific filters)
+* [Whitespace control](/api-reference/liquid/whitespace-control)
+* [Sanitization](/api-reference/liquid/sanitization)  
 * Examples for all of the above
 
-### GraphQL API
+{% include 'alert/tip', content: 'Interested in why we use Liquid or what sources we used for our documentation? Read our article titled [A Complete Guide to Liquid Markup (in platformOS)](https://www.platformos.com/blog/post/a-complete-guide-to-liquid-markup-in-platformos) on the platformOS blog.' %}
+  
+
+## GraphQL API
 
 **GraphQL** is query language used to communicate with our data storages. Our GraphQL API Reference includes:
 
@@ -32,4 +41,4 @@ This section provides API Reference Documentation for the APIs you'll use when d
 * Enums
 * Inputs
 
-We also provide guide on [how to effectively use `pos-cli`](/developer-guide/pos-cli/developing-graphql-queries-using-pos-cli-gui) while developing GraphQL queries in platformOS.
+We also provide a guide on [how to effectively use the `pos-cli`](/developer-guide/pos-cli/developing-graphql-queries-using-pos-cli-gui) while developing GraphQL queries in platformOS. 

--- a/app/views/pages/api-reference/liquid/introduction.liquid
+++ b/app/views/pages/api-reference/liquid/introduction.liquid
@@ -1,13 +1,13 @@
 ---
 converter: markdown
 metadata:
-  title: Liquid - Introduction
-  description: Introduction to Liquid
+  title: Liquid Markup - Introduction
+  description: Introduction to Liquid Markup
   toc: true
 ---
 
-Liquid is a template language used in platformOS to build dynamic pages, and to provide dynamic configuration (e.g. based on currently logged in user).
-Use Liquid to provide an authorization policy for forms and pages, or to specify notifications (email, SMS, API call). We have added a lot of filters and tags to make your life easier.
+Liquid (or Liquid markup) is a template language used in platformOS to build dynamic pages, and to provide dynamic configuration (e.g. based on currently logged in user).
+Use Liquid to provide an authorization policy for forms and pages, or to specify notifications (email, SMS, API call). We have added a lot of  filters and tags to make your life easier.
 
 ## Output
 


### PR DESCRIPTION
Fixes #1168

Added: 
- "Liquid markup" used more in the Introduction
- longer description on the API Reference page
- links to Liquid API reference sections
- link to related blog post as tip 

Preview:
- https://diana-documentation.staging.oregon.platform-os.com/api-reference/liquid/introduction
- https://diana-documentation.staging.oregon.platform-os.com/api-reference/graphql/rootquery.html

