### PR TITLE
Adds Liquid Theme tags

### DIFF
--- a/app/views/pages/api-reference/liquid/theme.liquid
+++ b/app/views/pages/api-reference/liquid/theme.liquid
@@ -1,0 +1,49 @@
+---
+converter: markdown
+metadata:
+  title: 'Liquid - Tags: Theme'
+  description: Liquid Tags - Theme
+  toc: true
+---
+
+## liquid
+Allows writing multiple tags within one set of delimiters. Use the [echo](/api-reference/liquid/theme#echo) tag to output an expression within a ```{% raw %}{% liquid %}{% endraw %}``` tag.
+
+#### Input
+
+```liquid
+{% raw %}
+{% liquid
+case section.blocks.size
+when 1
+  assign column_size = ''
+when 2
+  assign column_size = 'one-half'
+when 3
+  assign column_size = 'one-third'
+else
+  assign column_size = 'one-quarter'
+endcase %}
+{% endraw %}
+```
+
+## echo
+Outputs an expression in the rendered HTML. This is identical to wrapping an expression in ```{% raw %}{{{% endraw %}``` and ```{% raw %}}}{% endraw %}```, but works inside liquid tags and supports filters.
+
+#### Input
+
+```liquid
+{% raw %}
+
+
+{% endraw %}
+```
+
+#### Output
+
+```liquid
+
+```
+
+
+{% include 'reference/liquid/resource-note-shopify' %}

--- a/app/views/partials/shared/nav/api-reference.liquid
+++ b/app/views/partials/shared/nav/api-reference.liquid
@@ -9,6 +9,7 @@
     {% include "shared/nav/link", href: "/api-reference/liquid/flow-control", text: "Tags: Flow Control" %}
     {% include "shared/nav/link", href: "/api-reference/liquid/loops", text: "Tags: Loops" %}
     {% include "shared/nav/link", href: "/api-reference/liquid/include", text: "Tags: Include" %}
+    {% include "shared/nav/link", href: "/api-reference/liquid/theme", text: "Tags: Theme" %}
     {% include "shared/nav/link", href: "/api-reference/liquid/objects", text: "Objects" %}
     {% include "shared/nav/link", href: "/api-reference/liquid/platformos-filters", text: "Filters: platformOS" %}
     {% include "shared/nav/link", href: "/api-reference/liquid/filters", text: "Filters" %}


### PR DESCRIPTION
Fixes #1183 

@pavelloz or @piotrze  Please 

- review `liquid` tag example and change to pOS-specific example if needed
- add example input and output to `echo` tag

Preview: 
https://diana-documentation.staging.oregon.platform-os.com/api-reference/liquid/theme#echo 

Thank you! 