### PR TITLE
Bumped text size for better legibility

### DIFF
--- a/app/views/pages/index.liquid
+++ b/app/views/pages/index.liquid
@@ -35,7 +35,7 @@ response_headers: >
       <div class="mb-20 text-center md:flex md:justify-center">
         <div class="mt-10 md:w-1/3 md:mx-20 md:mt-10">
           <h3 class="mb-4 text-lg">Community</h3>
-          <p class="font-light text-body">Join in, grow your skills, and find people who share your interest in platformOS.</p>
+          <p class="text-body">Join in, grow your skills, and find people who share your interest in platformOS.</p>
 
           <a href="/community" class="inline-block mt-6 text-sm font-semibold no-underline text-pos-blue hover:text-pos-darkblue">
             JOIN OUR COMMUNITY
@@ -50,7 +50,7 @@ response_headers: >
 
         <div class="relative mt-16 md:w-1/3 md:mx-20 md:mt-10">
           <h3 class="mb-4 text-lg">Get Involved</h3>
-          <p class="font-light text-body">Learn about the many ways you can contribute to our documentation.</p>
+          <p class="text-body">Learn about the many ways you can contribute to our documentation.</p>
 
           <a href="/community/contributor-guide" class="inline-block mt-6 text-sm font-semibold no-underline text-pos-blue hover:text-pos-darkblue">
             CHECK OUT OUR CONTRIBUTOR GUIDE

--- a/app/views/pages/try-now.liquid
+++ b/app/views/pages/try-now.liquid
@@ -75,7 +75,7 @@ metadata:
             <h3 class="inline-block ml-2 pointer-events-none">1-Click Install</h3>
 
             <div class="pb-4 mt-4 md:ml-16">
-              <ul class="font-light">
+              <ul>
                 <li>Register on the Partner Portal</li>
                 <li>Create a fully functional demo site  with a single click</li>
                 <li>Install a blog</li>
@@ -106,7 +106,7 @@ metadata:
             <h3 class="inline-block ml-2">Sandbox</h3>
 
             <div class="pb-4 mt-4 md:ml-16">
-              <ul class="font-light">
+              <ul>
                 <li>Register on the Partner Portal</li>
                 <li>Clone a platformOS codebase from our demo GitHub repository</li>
                 <li>Use it as your own sandbox</li>

--- a/app/views/partials/home/section-options.liquid
+++ b/app/views/partials/home/section-options.liquid
@@ -9,7 +9,7 @@
 
         <div>
           <h2 class="mb-6 text-lg font-medium hover:text-pos-blue">Get Started</h2>
-          <p class="text-sm font-light">Follow step-by-step tutorials to set up your development environment and build a sample site or app on platformOS.</p>
+          <p>Follow step-by-step tutorials to set up your development environment and build a sample site or app on platformOS.</p>
         </div>
       </a>
     </div>
@@ -22,7 +22,7 @@
 
         <div>
           <h2 class="mb-6 text-lg font-medium hover:text-pos-blue">Developer Guide</h2>
-          <p class="text-sm font-light">Explore detailed descriptions of concepts, step-by-step tutorials, references, and examples for implementing various features on platformOS.</p>
+          <p>Explore detailed descriptions of concepts, step-by-step tutorials, references, and examples for implementing various features on platformOS.</p>
         </div>
       </a>
     </div>
@@ -35,7 +35,7 @@
 
         <div>
           <h2 class="mb-6 text-lg font-medium hover:text-pos-blue">API Reference</h2>
-          <p class="text-sm font-light">Consult our comprehensive documentation for the platformOS API including GraphQL API reference, and Liquid filters.</p>
+          <p>Consult our comprehensive documentation for the platformOS API including GraphQL API reference, and Liquid filters.</p>
         </div>
       </a>
     </div>
@@ -48,7 +48,7 @@
 
         <div>
           <h2 class="mb-6 text-lg font-medium hover:text-pos-blue">Best Practices</h2>
-          <p class="text-sm font-light">Get expert advice on platformOS best practices in a wide variety of topics.</p>
+          <p>Get expert advice on platformOS best practices in a wide variety of topics.</p>
         </div>
       </a>
     </div>
@@ -61,7 +61,7 @@
 
         <div>
           <h2 class="mb-6 text-lg font-medium hover:text-pos-blue">Use Cases</h2>
-          <p class="text-sm font-light">Explore how to implement real-life use cases.</p>
+          <p>Explore how to implement real-life use cases.</p>
         </div>
       </a>
     </div>
@@ -74,7 +74,7 @@
 
         <div>
           <h2 class="mb-6 text-lg font-medium hover:text-pos-blue">Release Notes</h2>
-          <p class="text-sm font-light">Learn about new features, deprecations, improvements, and fixes in platformOS from our regular release notes.</p>
+          <p>Learn about new features, deprecations, improvements, and fixes in platformOS from our regular release notes.</p>
         </div>
       </a>
     </div>

--- a/app/views/partials/layouts/content/breadcrumbs.liquid
+++ b/app/views/partials/layouts/content/breadcrumbs.liquid
@@ -1,7 +1,7 @@
 {% assign slugTitleized = context.params.slug | titleize %}
 
-<div class="w-full my-4 breadcrumbs">
-  <ul class="flex flex-wrap justify-end text-sm list-none sm:flex-no-wrap">
+<div class="w-full my-4 breadcrumbs px-4 sm:px-0">
+  <ul class="flex flex-wrap justify-end list-none sm:flex-no-wrap">
     <li class="flex items-center">
       <a href="/" class="no-underline text-pos-blue hover:text-pos-darkblue hover:underline">Documentation</a>
     </li>

--- a/app/views/partials/layouts/content/callout.liquid
+++ b/app/views/partials/layouts/content/callout.liquid
@@ -1,7 +1,7 @@
 {% capture callout_questions %}
-  <h2 class="text-xl">Questions?</h2>
+  <h2 class="text-2xl">Questions?</h2>
 
-  <p class="my-8 text-lg font-light">We are always happy to help with any questions you may have.</p>
+  <p class="my-8 text-lg">We are always happy to help with any questions you may have.</p>
 
   <a href="/contact" class="btn btn-primary">contact us</a>
 {% endcapture %}

--- a/app/views/partials/layouts/header.liquid
+++ b/app/views/partials/layouts/header.liquid
@@ -11,31 +11,31 @@
       <ul class="flex flex-wrap items-center justify-center list-none sm:ml-6">
         <li class="w-full text-center sm:w-auto sm:text-left">
           <a href="/get-started"
-            class="{% if cp contains '/get-started' %}text-pos-blue{% endif %} no-underline text-lg hover:text-pos-blue leading-loose py-1 sm:text-sm">
+            class="{% if cp contains '/get-started' %}text-pos-blue{% endif %} no-underline text-lg hover:text-pos-blue leading-loose py-1 sm:text-base">
             Get Started
           </a>
         </li>
         <li class="w-full text-center sm:w-auto sm:text-left sm:ml-5 md:ml-10">
           <a href="/developer-guide"
-            class="{% if cp contains '/developer-guide' %}text-pos-blue{% endif %} no-underline text-lg hover:text-pos-blue leading-loose py-1 sm:text-sm">
+            class="{% if cp contains '/developer-guide' %}text-pos-blue{% endif %} no-underline text-lg hover:text-pos-blue leading-loose py-1 sm:text-base">
             Developer Guide
           </a>
         </li>
         <li class="w-full text-center sm:w-auto sm:text-left sm:ml-5 md:ml-10">
           <a href="/api-reference"
-            class="{% if cp contains '/api-reference' %}text-pos-blue{% endif %} no-underline text-lg hover:text-pos-blue leading-loose py-1 sm:text-sm">
+            class="{% if cp contains '/api-reference' %}text-pos-blue{% endif %} no-underline text-lg hover:text-pos-blue leading-loose py-1 sm:text-base">
             API Reference
           </a>
         </li>
         <li class="w-full text-center sm:w-auto sm:text-left sm:ml-5 md:ml-10">
           <a href="/best-practices"
-            class="{% if cp contains '/best-practices' %}text-pos-blue{% endif %} no-underline text-lg hover:text-pos-blue leading-loose py-1 sm:text-sm">
+            class="{% if cp contains '/best-practices' %}text-pos-blue{% endif %} no-underline text-lg hover:text-pos-blue leading-loose py-1 sm:text-base">
             Best Practices
           </a>
         </li>
         <li class="w-full text-center sm:w-auto sm:text-left sm:ml-5 md:ml-10">
           <a href="/use-cases"
-            class="{% if cp contains '/use-cases' %}text-pos-blue{% endif %} no-underline text-lg hover:text-pos-blue leading-loose py-1 sm:text-sm">
+            class="{% if cp contains '/use-cases' %}text-pos-blue{% endif %} no-underline text-lg hover:text-pos-blue leading-loose py-1 sm:text-base">
             Use Cases
           </a>
         </li>

--- a/src/css/base.css
+++ b/src/css/base.css
@@ -1,5 +1,5 @@
 body {
-  @apply text-body bg-white leading-normal text-sm antialiased font-normal;
+  @apply text-body bg-white antialiased;
 }
 
 a {

--- a/src/css/layout/content.css
+++ b/src/css/layout/content.css
@@ -23,7 +23,7 @@ main {
   }
 
   h4 {
-    @apply text-lg font-light;
+    @apply text-lg;
   }
 
   h5 {

--- a/src/css/pages/release-notes.css
+++ b/src/css/pages/release-notes.css
@@ -7,7 +7,7 @@ h4 {
 }
 
 h4 + ul {
-  @apply text-lg font-light;
+  @apply text-lg;
 }
 
 .release-notes__year-container {


### PR DESCRIPTION
Change body size from effective 14px to 16px. 
Restored 1.5 default line-height.
Removed instances of `font-light` on text smaller than 3xl (which is almost everywhere).
Updated breadcrumbs layout on small screens.