### PR TITLE
Info about the translations in modules

### DIFF
--- a/app/views/pages/developer-guide/modules/modules.liquid
+++ b/app/views/pages/developer-guide/modules/modules.liquid
@@ -176,6 +176,20 @@ But it is referenced with the prefix:
 {% endraw %}
 ```
 
+### Translations
+
+[Translations](/developer-guide/translations/translations) YML files for module should be placed in:
+
+##### modules/admin/public/translations/
+
+But when used in the module code they should be prefixed:
+
+```liquid
+{{ 'modules/admin/strings.sample_string' | t }}
+```
+
+
+
 ## Related topics
 
 * [Creating a Module](/developer-guide/modules/creating-module)


### PR DESCRIPTION
I didn't know the translations should be prefixed when used inside a module so this might be helpful.