### PR TITLE
Removes json filter from examples

### DIFF
--- a/app/views/pages/api-reference/liquid/sanitization.liquid
+++ b/app/views/pages/api-reference/liquid/sanitization.liquid
@@ -38,8 +38,8 @@ This is especially important when you try to construct a JSON output.
 {% assign color = 'red' %}
 {% assign link = '<a href="/car">cars</a>' %}
 {
-  "color": {{ color | json }},
-  "link": {{ link | json | html_safe }}
+  "color": {{ color }},
+  "link": {{ link | html_safe }}
 }
 {% endraw %}
 ```
@@ -49,8 +49,8 @@ This is especially important when you try to construct a JSON output.
 {% assign color = 'red' %}
 {% assign link = '<a href="/car">cars</a>' %}
 {
-  "color": {{ color | json }},
-  "link": {{ link | json }}
+  "color": {{ color }},
+  "link": {{ link }}
 }
 ```
 

--- a/app/views/pages/best-practices/amp/feeding-data-amp-pages-graphql.liquid
+++ b/app/views/pages/best-practices/amp/feeding-data-amp-pages-graphql.liquid
@@ -86,10 +86,10 @@ Create the JSON endpoint, a dynamically generated JSON document from which AMP f
   "items": [
     {% for product in results %}
       {
-        "name": {{ product.name | json }},
-        "slug": {{ product.slug | json }},
-        "description": {{ product.description | json }},
-        "image": {{ product.photo.url | json }},
+        "name": {{ product.name }},
+        "slug": {{ product.slug }},
+        "description": {{ product.description }},
+        "image": {{ product.photo.url }},
         "price": {{ product.price }}
       }{% unless forloop.last %},{% endunless %}
     {% endfor %}

--- a/app/views/pages/developer-guide/activity-feeds/handling-read-activites.liquid
+++ b/app/views/pages/developer-guide/activity-feeds/handling-read-activites.liquid
@@ -59,7 +59,7 @@ You can reset `unread_count` with the same query by setting `$reset_last_read` t
 
 Imagine the following scenario:
 - you want to reset the counter when the user visits the activities (or notifications) page
-- but you want to keep the activites that the user has not clicked yet unread 
+- but you want to keep the activites that the user has not clicked yet unread
 
 You can implement this scenario with the following steps:
 
@@ -92,8 +92,8 @@ You can implement this scenario with the following steps:
 ```liquid
 {% raw %}
 {% capture 'notifications' -%}
-  { "total_entries": {{ g.streams.total_entries | json }},
-    "unread_count": {{ g.streams.unread_count | json }},
+  { "total_entries": {{ g.streams.total_entries }},
+    "unread_count": {{ g.streams.unread_count }},
     "results": [
       {%- for notification in notifications -%}
         {%- assign is_clicked = false -%}
@@ -102,12 +102,12 @@ You can implement this scenario with the following steps:
         {%- endif -%}
         {%- unless forloop.first -%},{%- endunless -%}
         {
-          "id": {{ notification.id | json }},
-          "uuid": {{ notification.uuid | json }},
-          "clicked": {{ is_clicked | json -}},
+          "id": {{ notification.id }},
+          "uuid": {{ notification.uuid }},
+          "clicked": {{ is_clicked -}},
           "payload": {
             {%- for field in notification.payload -%}
-              "{{ field[0] }}" : {{ field[1] | json }}{%- unless forloop.last -%},{%- endunless -%}
+              "{{ field[0] }}" : {{ field[1] }}{%- unless forloop.last -%},{%- endunless -%}
             {%- endfor -%}
           }
         }
@@ -123,7 +123,7 @@ You can implement this scenario with the following steps:
 
 ```liquid
 {% raw %}
-{% liquid 
+{% liquid
   assign recipients = context.current_user.id | split: "|"
   graphql notifications = 'get_activities', user_id: context.current_user.id | dig: 'streams', 'results'
 

--- a/app/views/pages/developer-guide/assets/using-static-assets-pages.liquid
+++ b/app/views/pages/developer-guide/assets/using-static-assets-pages.liquid
@@ -64,7 +64,7 @@ Use {% raw %}`{{ asset_url }}`{% endraw %} variable to check your assets. This w
 Example for this documentation site:
 
 ```liquid
-{{ asset_url | json }}
+{{ asset_url }}
 ```
 
 

--- a/app/views/pages/developer-guide/data-import-export/import.liquid
+++ b/app/views/pages/developer-guide/data-import-export/import.liquid
@@ -191,7 +191,7 @@ method: post
   records: context.params.records
 %}
 
-{{ g | json }}
+{{ g }}
 ```
 {% endraw %}
 

--- a/app/views/pages/developer-guide/payments/processing-payments-graphql-mutations.liquid
+++ b/app/views/pages/developer-guide/payments/processing-payments-graphql-mutations.liquid
@@ -76,8 +76,8 @@ The configuration and data are prepared. You now need to wrap it in the format t
 {% parse_json "refund_data" %}
   {
     "properties": [
-       { "name": "config", "value": "{{ config | json | escape_javascript }}" },
-       { "name": "data", "value":  "{{ data | json | escape_javascript }}" }
+       { "name": "config", "value": "{{ config | escape_javascript }}" },
+       { "name": "data", "value":  "{{ data | escape_javascript }}" }
      ]
   }
 {% endparse_json %}

--- a/app/views/pages/developer-guide/records/crud-records-using-ajax.liquid
+++ b/app/views/pages/developer-guide/records/crud-records-using-ajax.liquid
@@ -156,7 +156,7 @@ Then you need to create a page that returns JSON with the data:
 ```liquid
 {%- raw -%}
 {%- graphql recent = "modules/feedback/feedback", per_page: 10 -%}
-{{ recent.records.results | json }}
+{{ recent.records.results }}
 {% endraw %}
 ```
 

--- a/app/views/pages/use-cases/building-blog.liquid
+++ b/app/views/pages/use-cases/building-blog.liquid
@@ -86,7 +86,7 @@ To access parameters passed in the URL in Liquid markup, use the `extract_url_pa
 
 {{ url_params }} => {"maker"=>"honda", "model"=>"crx"}
 {{ url_params.maker }} => "honda"
-{{ url_params | json }} => {"maker":"honda","model":"crx"}
+{{ url_params }} => {"maker":"honda","model":"crx"}
 {% endraw %}
 ```
 


### PR DESCRIPTION
Fixes #1337 

I removed the json filter from the examples, except for old release notes so that there's a history of what happened. Please review! Thank you! 