### PR TITLE
Adds where filter

### DIFF
--- a/app/views/pages/api-reference/liquid/filters.liquid
+++ b/app/views/pages/api-reference/liquid/filters.liquid
@@ -1792,3 +1792,92 @@ Converts any URL-unsafe characters in a string into percent-encoded characters.
 ```liquid
 {{ "Nikola Tesla" | url_encode }}
 ```
+
+## where
+
+Creates an array including only the objects with a given property value, or any `truthy` value by default.
+
+In this example, assume that you have a list of products and you want to show your kitchen products separately. Using `where`, you can create an array containing only the products that have a `"type"` of `"kitchen"`.
+
+#### Input
+
+```liquid
+{% raw %}
+All products:
+{% for product in products %}
+- {{ product.title }}
+{% endfor %}
+
+{% assign kitchen_products = products | where: "type", "kitchen" %}
+
+Kitchen products:
+{% for product in kitchen_products %}
+- {{ product.title }}
+{% endfor %}
+{% endraw %}
+```
+
+#### Output
+
+```liquid
+All products:
+- Vacuum
+- Spatula
+- Television
+- Garlic press
+
+Kitchen products:
+- Spatula
+- Garlic press
+```
+
+Say instead you have a list of products and you only want to show those that are available to buy. You can use `where` with a property name but no target value to include all products with a truthy `"available"` value.
+
+#### Input
+
+```liquid
+{% raw %}
+All products:
+{% for product in products %}
+- {{ product.title }}
+{% endfor %}
+
+{% assign available_products = products | where: "available" %}
+
+Available products:
+{% for product in available_products %}
+- {{ product.title }}
+{% endfor %}
+{% endraw %}
+```
+
+#### Output
+
+```liquid
+All products:
+- Coffee mug
+- Limited edition sneakers
+- Boring sneakers
+
+Available products:
+- Coffee mug
+- Boring sneakers
+```
+
+The `where` filter can also be used to find a single object in an array when combined with the first filter. For example, say you want to show off the shirt in your new fall collection.
+
+#### Input
+
+```liquid
+{% raw %}
+{% assign new_shirt = products | where: "type", "shirt" | first %}
+Featured product: {{ new_shirt.title }}
+{% endraw %}
+```
+
+#### Output
+
+```liquid
+Featured product: Hawaiian print sweater vest
+```
+


### PR DESCRIPTION
Fixes #1414 

@pavelloz I added the documentation for the `where` filter from the official Liquid docs, as it seemed to be relevant for a marketplace use case. Please change it to a pOS-specific example if needed. 

I know the output is not liquid but in order to put the output in a code block, I found that this worked (without the liquid part it put the code in separate lines). 

Thank you for your review! 

Preview: https://diana-documentation.staging.oregon.platform-os.com/api-reference/liquid/filters#where