### PR TITLE
Graphq api reference: fix menu links to types/enums

### DIFF
--- a/app/views/partials/shared/nav/api-reference.liquid
+++ b/app/views/partials/shared/nav/api-reference.liquid
@@ -47,7 +47,7 @@
             <ul class="submenu">
               {% for el5 in el4[1] %}
                 <li>
-                  <a href="/api-reference/graphql/{{el3[0]}}/{{el4[0]}}/{{ el5[0] | replace: '_', '-' | downcase }}">{{ el5[0] }}</a>
+                  <a href="/api-reference/graphql/{{el3[0]}}/{{el4[0]}}/{{ el5[0] | titleize | slugify  }}">{{ el5[0] }}</a>
                 </li>
               {% endfor %}
             </ul>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/96238/144080340-9ecf555c-c560-49a8-a495-2f859204fbe7.png)
