### PR TITLE
Module Path - Fix

### DIFF
--- a/app/views/pages/developer-guide/assets/assets.liquid
+++ b/app/views/pages/developer-guide/assets/assets.liquid
@@ -101,8 +101,8 @@ Assets in modules are namespaced to not conflict with each other. They are also 
 {% raw %}
 File location: `modules/[my_module]/public/assets/js/app.js`
 
-Asset url filter access: `{{ 'modules/[my_module]/assets/js/app.js' | asset_url }}`
-Asset path filter access: `{{ 'modules/[my_module]/assets/js/app.js' | asset_path }}`
+Asset url filter access: `{{ 'modules/[my_module]/js/app.js' | asset_url }}`
+Asset path filter access: `{{ 'modules/[my_module]/js/app.js' | asset_path }}`
 {% endraw %}
 
 ## Removing assets


### PR DESCRIPTION
Extras `/assets` in path which causes assets to not be found by `asset_url` and `asset_path`