### PR TITLE
Added introduction link to left nav

### DIFF
--- a/app/views/partials/shared/nav/get-started.liquid
+++ b/app/views/partials/shared/nav/get-started.liquid
@@ -1,4 +1,4 @@
-<li class="{% if cp contains '/get-started' %}active{% endif %}">
+<li class="{% if cp == '/get-started' %}active{% endif %}">
   <a href="/get-started">Introduction</a>
 </li>
 

--- a/app/views/partials/shared/nav/get-started.liquid
+++ b/app/views/partials/shared/nav/get-started.liquid
@@ -1,3 +1,7 @@
+<li class="{% if cp contains '/get-started' %}active{% endif %}">
+  <a href="/get-started">Introduction</a>
+</li>
+
 <li class="{% if cp contains '/hello-world' %}active{% endif %}">
   <a href="/get-started/hello-world/hello-world">Hello, World!</a>
 


### PR DESCRIPTION
Since the 'Get started' section introduction now offers valuable information I believe it should be easy to get back to it from the left navigation so added the introduction link there.

![image](https://user-images.githubusercontent.com/1907443/195266106-18cd3b8f-431e-4d74-9510-685580fe779d.png)
