### PR TITLE
Updated the onboarding

### DIFF
--- a/app/views/pages/get-started.liquid
+++ b/app/views/pages/get-started.liquid
@@ -101,3 +101,6 @@ pos-cli sync &lt;environment&gt;
 **Our community can help!** platfromOS community is an open forum for all users that help share the experience and knowledge gathered from working on platformOS-specific projects.
 
 [Join platformOS community](https://community.platformos.com/)
+
+
+{% render 'alert/next', content: 'Working with the code and files', url: '/get-started/installation-and-configuration/' %}

--- a/app/views/pages/get-started.liquid
+++ b/app/views/pages/get-started.liquid
@@ -3,12 +3,12 @@ metadata:
   title: Get Started
   description: Follow these step-by-step tutorials to set up your development environment and deploy your first platformOS site.
 converter: markdown
-layout: application
 ---
 
 Welcome to platformOS! Our Get Started guides will walk you through the steps of building a sample site or app on platformOS. They include detailed explanations for each step, example code, tips and best practices on development workflow and QA, and links to learn more.
 
-## What you need to know to start
+
+## What you need to know
 
 Besides standard web technologies like HTML, CSS, JavaScript, platformOS uses a couple of languages and technologies that you need to be familiar with to build a site on our platform.
 
@@ -28,7 +28,7 @@ Besides standard web technologies like HTML, CSS, JavaScript, platformOS uses a 
 
 **Liquid** is a template language that allows you to build dynamic pages and provide dynamic configuration. In the Get Started guide we will be using it to server-side render data and to manage how the page behaves depending on user's action. You can check out the following articles but you can also learn while doing – it should be simple to understand.
 
-- [A Complete Guide to Liquid Markup](https://documentation.platformos.com/api-reference/liquid/introduction) by the platformOS team
+- [A Complete Guide to Liquid Markup](/api-reference/liquid/introduction) by the platformOS team
 - [Learning Liquid](https://www.shopify.com/partners/blog/topics/learning-liquid)
 - [SHOPIFY LIQUID: Theme Programming for Beginners](https://www.youtube.com/watch?v=zBtwd2OfZsI)
 
@@ -38,13 +38,64 @@ Besides standard web technologies like HTML, CSS, JavaScript, platformOS uses a 
 - [Get started with YAML in 5 minutes](https://www.educative.io/blog/yaml-tutorial)
 
 
+## Not sure where to start?
 
-## Hello, World!
+Let’s build a simple website together! If you are new to platformOS, we propose that you start with a simple course that we’ve prepared.
 
-[Hello, World!](/get-started/hello-world/hello-world) is the first part of our Get Started guide, that will teach you how to set up your development environment, create a simple site, make a small change on the home page, and deploy it. This is to make sure you have everything you need and everything works. You can stop here and start experimenting based on our documentation, or you can move on to the second part of our Get Started guides.
+You will learn how to set up your environment, how to get a starter codebase and how to deploy everything to your platfromOS instance. Next, we’ll gona build a simple to-do app using all of the core platformOS concepts.
 
-## Build a ToDo List App
+Ready? Let’s learn how to [install and configure]() your development environment.
 
-[Build a ToDo List App](/get-started/todo-app/build-todo-list-app) is the second part of our Get Started guide that walks you through the steps of creating a ToDo List app on platformOS from setting up your development environment to deploying and testing your finished app. It explains basic concepts, main building blocks, and the logic behind platformOS, while also giving you some recommendations on workflow.
 
-[Build a ToDo List App - Part 2: Extend Your App](/get-started/todo-app/build-todo-list-app-part-2) shows you how to extend what you have built in part 1 to explore additional platformOS features in greater depth and learn about more best practices.
+## Quick start
+
+1. Go to Partner Portal and [sign up](https://partners.platformos.com/accounts/sign_up)
+2. [Create new instance](https://partners.platformos.com/instances/new) in Partner Portal
+3. Install pos-cli
+    platformOS command-line interface is distributed through NPM.
+  <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+npm install -g @platformos/pos-cli
+  </code></pre>
+4. Create an empty folder for your project
+5. Navigate to project's folder in command line
+  <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+cd x:\platformos-hello
+  </code></pre>
+6. Initialize platformOS directory structure
+  <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli init
+  </code></pre>
+7. Authenticate your environment
+  <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli env add &lt;environment&gt; --email &lt;your email&gt; --url &lt;your instance url&gt;
+  </code></pre>
+8. Upload your code to the instance
+  <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli deploy &lt;environment&gt;
+  </code></pre>
+9. Upload code changes automatically when you save the file
+  <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli sync &lt;environment&gt;
+  </code></pre>
+
+
+## Learn the core concepts
+- **[Developement workflow](/developer-guide/platformos-workflow/development-workflow)**
+  Learn the steps needed to deploy your code to a platfromOS instance.
+- **[Codebase structure](/developer-guide/platformos-workflow/codebase)**
+  A detailed walk through the directories and files required to work on the platform.
+- **[platformOS Command Line Interface](/developer-guide/pos-cli/pos-cli)**
+  Check out how to use the command line to interact with your instance.
+- **[Routing and templates](/developer-guide/pages/pages)**
+  Step-by-step guide on how the routing and creating subpages work on platformOS.
+- **[Schema](/developer-guide/users/users)**
+- **[Modules](/developer-guide/modules/modules)**
+  The platform supports and encourages building modular codebases. This guide will show you how to do that.
+- **[Data management](/developer-guide/data-import-export/import)**
+  If you need to import or export previously prepared data, you’ll find the answers here.
+
+
+## Still having questions?
+**Our community can help!** platfromOS community is an open forum for all users that help share the experience and knowledge gathered from working on platformOS-specific projects.
+
+[Join platformOS community](https://community.platformos.com/)

--- a/app/views/pages/get-started.liquid
+++ b/app/views/pages/get-started.liquid
@@ -42,26 +42,26 @@ Besides standard web technologies like HTML, CSS, JavaScript, platformOS uses a 
 
 Let’s build a simple website together! If you are new to platformOS, we propose that you start with a simple course that we’ve prepared.
 
-You will learn how to set up your environment, get a starter codebase and how to deploy everything to your platfromOS instance. Next, we’ll  build a simple to-do app using all of the core platformOS concepts.
+You will learn how to set up your environment, get a starter codebase, and deploy everything to your platfromOS instance. Next, you’ll  build a simple to-do app using all of the core platformOS concepts.
 
 Ready? Let’s learn how to [install and configure](/get-started/installation-and-configuration/) your development environment.
 
 
 ## Quick start
 
-1. Go to Partner Portal and [sign up](https://partners.platformos.com/accounts/sign_up)
-2. [Create new instance](https://partners.platformos.com/instances/new) in Partner Portal
+1. Go to the Partner Portal and [sign up](https://partners.platformos.com/accounts/sign_up)
+2. [Create new instance](https://partners.platformos.com/instances/new) in the Partner Portal
 3. Install pos-cli
     platformOS command-line interface is distributed through NPM.
   <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 npm install -g @platformos/pos-cli
   </code></pre>
 4. Create an empty folder for your project
-5. Navigate to project's folder in command line
+5. Navigate to the project's folder in the command line
   <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 cd x:\platformos-hello
   </code></pre>
-6. Initialize platformOS directory structure
+6. Initialize the platformOS directory structure
   <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli init
   </code></pre>
@@ -81,9 +81,9 @@ pos-cli sync &lt;environment&gt;
 
 ## Learn the core concepts
 - **[Developement workflow](/developer-guide/platformos-workflow/development-workflow)**
-  Learn the steps needed to deploy your code to a platfromOS instance.
+  Learn the steps needed to deploy your code to a platformOS instance.
 - **[Codebase structure](/developer-guide/platformos-workflow/codebase)**
-  A detailed walk through the directories and files required to work on the platform.
+  A detailed walkthrough of the directories and files required to work on the platform.
 - **[platformOS Command Line Interface](/developer-guide/pos-cli/pos-cli)**
   Check out how to use the command line to interact with your instance.
 - **[Routing and templates](/developer-guide/pages/pages)**
@@ -93,15 +93,15 @@ pos-cli sync &lt;environment&gt;
 - **[Modules](/developer-guide/modules/modules)**
   The platform supports and encourages building modular codebases. This guide will show you how to do that.
 - **[Data management](/developer-guide/data-import-export/import)**
-  If you need to import or export previously prepared data, you’ll find the answers here.
+  If you need to import or export previously prepared data, this is how you can do it.
 - **[Effective Development Using the pos-cli](https://documentation.platformos.com/developer-guide/pos-cli/effective-development-using-pos-cli.liquid)**
-  A in-depth dive in clever techniques that can be used in everyday development.
+  A deep-dive into clever techniques for everyday development.
 
 
-## Still having questions?
-**Our community can help!** platfromOS community is an open forum for all users that help share the experience and knowledge gathered from working on platformOS-specific projects.
+## Still have questions?
+**Our community can help!** The platformOS community is open to all users to share the experience and knowledge gathered from working on platformOS-specific projects.
 
-[Join platformOS community](https://community.platformos.com/)
+[Join the platformOS community](https://community.platformos.com/)
 
 
 {% render 'alert/next', content: 'Working with the code and files', url: '/get-started/installation-and-configuration/' %}

--- a/app/views/pages/get-started.liquid
+++ b/app/views/pages/get-started.liquid
@@ -89,6 +89,7 @@ pos-cli sync &lt;environment&gt;
 - **[Routing and templates](/developer-guide/pages/pages)**
   Step-by-step guide on how the routing and creating subpages work on platformOS.
 - **[Schema](/developer-guide/users/users)**
+  Learn how to define models with properties and persist the data in it.
 - **[Modules](/developer-guide/modules/modules)**
   The platform supports and encourages building modular codebases. This guide will show you how to do that.
 - **[Data management](/developer-guide/data-import-export/import)**

--- a/app/views/pages/get-started.liquid
+++ b/app/views/pages/get-started.liquid
@@ -42,7 +42,7 @@ Besides standard web technologies like HTML, CSS, JavaScript, platformOS uses a 
 
 Let’s build a simple website together! If you are new to platformOS, we propose that you start with a simple course that we’ve prepared.
 
-You will learn how to set up your environment, how to get a starter codebase and how to deploy everything to your platfromOS instance. Next, we’ll gona build a simple to-do app using all of the core platformOS concepts.
+You will learn how to set up your environment, get a starter codebase and how to deploy everything to your platfromOS instance. Next, we’ll  build a simple to-do app using all of the core platformOS concepts.
 
 Ready? Let’s learn how to [install and configure](/get-started/installation-and-configuration/) your development environment.
 
@@ -93,6 +93,8 @@ pos-cli sync &lt;environment&gt;
   The platform supports and encourages building modular codebases. This guide will show you how to do that.
 - **[Data management](/developer-guide/data-import-export/import)**
   If you need to import or export previously prepared data, you’ll find the answers here.
+- **[Effective Development Using the pos-cli](https://documentation.platformos.com/developer-guide/pos-cli/effective-development-using-pos-cli.liquid)**
+  A in-depth dive in clever techniques that can be used in everyday development.
 
 
 ## Still having questions?

--- a/app/views/pages/get-started.liquid
+++ b/app/views/pages/get-started.liquid
@@ -44,7 +44,7 @@ Let’s build a simple website together! If you are new to platformOS, we propos
 
 You will learn how to set up your environment, how to get a starter codebase and how to deploy everything to your platfromOS instance. Next, we’ll gona build a simple to-do app using all of the core platformOS concepts.
 
-Ready? Let’s learn how to [install and configure]() your development environment.
+Ready? Let’s learn how to [install and configure](/get-started/installation-and-configuration/) your development environment.
 
 
 ## Quick start

--- a/app/views/pages/get-started/installation-and-configuration.liquid
+++ b/app/views/pages/get-started/installation-and-configuration.liquid
@@ -65,4 +65,4 @@ If everything went smoothly you should be seeing the version number of pos-cli t
 
 
 ## Next chapter
-[Working with the code and files](/get-started/working-with-the-code-and-files/)
+{% include 'alert/tutorial', content: '[Working with the code and files](/get-started/working-with-the-code-and-files/)' %}

--- a/app/views/pages/get-started/installation-and-configuration.liquid
+++ b/app/views/pages/get-started/installation-and-configuration.liquid
@@ -22,6 +22,8 @@ Make sure that you’ll verify your account by following the instructions you’
 
 For our web app to work, we need to have a place where we will be running our code and storing files. On platformOS such place is called an _instance_.
 
+{% include 'alert/tip', content: 'Each separate site that you can create in the Partner Portal is called an **instance**.' %}
+
 In order to create a new instance you need to be logged in the [Partner Portal](https://partners.platformos.com/) and in the left navigation you’ll find a [Create Instance](https://partners.platformos.com/instances/new) link.
 
 The _Instance name_ can be any name of your choice. The only other option you’ll need to be concerned would be choosing the _Data Center_ and _Billing plan_. For the needs of this guide we can use the _Staging_ environment, which is a **completely free** environment designed exactly for testing and developement.

--- a/app/views/pages/get-started/installation-and-configuration.liquid
+++ b/app/views/pages/get-started/installation-and-configuration.liquid
@@ -1,63 +1,63 @@
 ---
 metadata:
-  title: Installation and configuration
+  title: Installation and Configuration
   description: Follow these step-by-step tutorials to set up your development environment and deploy your first platformOS site.
 converter: markdown
 ---
 
 
-There are three key steps to start developing on platformOS: [signing up on Partner Portal](#sign-up-on-partner-portal), [creating an instance](#create-an-instance) and [installing the platformOS command line interface](#install-pos-cli).
+There are three key steps for starting development on platformOS: [signing up on the Partner Portal](#sign-up-on-partner-portal), [creating an instance](#create-an-instance) and [installing the platformOS command line interface](#install-pos-cli).
 
 
-## Sign up on Partner Portal
+## Sign up on the Partner Portal
 
-The [Partner Portal](https://partners.platform-os.com/) is an online interface, where you can create, manage and configure your sites.
+The [Partner Portal](https://partners.platform-os.com/) is an online interface, where you can create, manage, and configure your sites.
 
-To interact with platformOS you will need to have an account, so the very first thing you need to do is [registering on Partner Portal](https://partners.platformos.com/accounts/sign_up).
+To interact with platformOS you will need to have an account, so the very first thing you need to do is [register on the Partner Portal](https://partners.platformos.com/accounts/sign_up).
 
-Make sure that you’ll verify your account by following the instructions you’ll find in the e-mail we send you after the registration.
+Make sure that you’ll verify your account by following the instructions you’ll find in the email we send you after the registration.
 
 
 ## Create an instance
 
-For our web app to work, we need to have a place where we will be running our code and storing files. On platformOS such place is called an _instance_.{% include 'alert/tip', content: 'Each separate site that you can create in the Partner Portal is called an **instance**.' %}
+For your web app to work, you need to have a place where you will be running your code and storing files. On platformOS such place is called an _instance_.{% include 'alert/tip', content: 'Each separate site that you can create in the Partner Portal is called an **instance**.' %}
 
 In order to create a new instance you need to be logged in the [Partner Portal](https://partners.platformos.com/) and in the left navigation you’ll find a [Create Instance](https://partners.platformos.com/instances/new) link.
 
-The _Instance name_ can be any name of your choice. The only other option you’ll need to be concerned would be choosing the _Data Center_ and _Billing plan_. For the needs of this guide we can use the _Staging_ environment, which is a **completely free** environment designed exactly for testing and developement.
+The _Instance name_ can be any name of your choice. The only other options you’ll need to choose are the _Data Center_ and _Billing plan_. For the needs of this guide we can use the _Staging_ environment, which is a **completely free** environment designed for testing and developement.
 
-Choosing the _Staging_ data center and clicking on the _Staging Unbilled_ plan should be enough for you to create your first very own instance!
+Choosing the _Staging_ data center and clicking on the _Staging Unbilled_ plan should be enough for you to create your first instance. 
 
-On the list of instances you may initially see your instance marked with _SCHEDULED_TO_ACTIVATE_ status. This proces usually takes only a couple of seconds, so no need to worry.
+On the list of instances, you may initially see your instance marked with the _SCHEDULED_TO_ACTIVATE_ status. This process usually takes only a couple of seconds.
 
-After a short while you should see the status changed to _Active_ when you refresh the page. This means that we can go to the instance URL visible in the list and actually check if it's working! This URL will be where we’ll see all the code changes so please note it’s importance.
+After a short while, you should see the status changed to _Active_ when you refresh the page. This means that you can go to the instance URL visible in the list and check if it's working. This URL is important: you’ll see all the code changes here. 
 
 
 ## Install pos-cli
 
 The platformOS command line interface – or `pos-cli` – is a tool that will allow you to interact with your instance.
 
-The tool itself offers a variety of options, and we’ll explore it in future sections of this guide, or you can jump right in to [pos-cli documentation](/developer-guide/pos-cli/pos-cli).
+The pos-cli offers a variety of options that you can explore in later sections of this guide, or you can jump right in to the [pos-cli documentation](/developer-guide/pos-cli/pos-cli).
 
-**To install pos-cli** you’ll need a recent version of NPM (Node Package Manager) installed on your system. The NPM itself is distributed with Node.js, so we recommend you follow the [official guide for installing Node.js and NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). If you get lost there, it might be the easiest to use [node.js installer](https://nodejs.org/en/download/) that will look just like installing any other program on your system.
+**To install the pos-cli** you’ll need a recent version of NPM (Node Package Manager) installed on your system. NPM is distributed with Node.js, so we recommend you follow the [official guide for installing Node.js and NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). If you get lost there, it might be the easiest to use the [node.js installer](https://nodejs.org/en/download/) that will look just like installing any other program on your system.
 
 Once you have Node.js installed, start your command-line tool of choice and run the following:<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 npm install -g @platformos/pos-cli
 </code></pre>
 
-The `-g` attribute means we are installing the tool globally. That might require having a higher system permissions. On unix-based systems that means using sudo and on Windows it might require runing your command-line tool with the administrative rights (it should be available in the right-click context menu).
+The `-g` attribute means you are installing the tool globally. That might require having higher system permissions. On unix-based systems that means using sudo and on Windows it might require running your command-line tool with the administrative rights (it should be available in the right-click context menu).
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 sudo npm install -g @platformos/pos-cli
 </code></pre>
 
-After installing pos-cli you should be able to test if everything ran successfully with the following command:
+After installing the pos-cli you should be able to test if everything ran successfully with the following command:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli -v
 </code></pre>
 
-If everything went smoothly you should be seeing the version number of pos-cli tool that you’ve just installed (for example: `4.7.1`).
+If everything went smoothly, the version number of the pos-cli tool that you’ve just installed is displayed (for example: `4.7.1`).
 
 
 {% render 'alert/next', content: 'Working with the code and files', url: '/get-started/working-with-the-code-and-files/' %}

--- a/app/views/pages/get-started/installation-and-configuration.liquid
+++ b/app/views/pages/get-started/installation-and-configuration.liquid
@@ -1,0 +1,66 @@
+---
+metadata:
+  title: Installation and configuration
+  description: Follow these step-by-step tutorials to set up your development environment and deploy your first platformOS site.
+converter: markdown
+---
+
+
+There are three key steps to start developing on platformOS: [signing up on Partner Portal](#sign-up-on-partner-portal), [creating an instance](#create-an-instance) and [installing the platformOS command line interface](#install-pos-cli).
+
+
+## Sign up on Partner Portal
+
+The [Partner Portal](https://partners.platform-os.com/) is an online interface, where you can create, manage and configure your sites.
+
+To interact with platformOS you will need to have an account, so the very first thing you need to do is [registering on Partner Portal](https://partners.platformos.com/accounts/sign_up).
+
+Make sure that you’ll verify your account by following the instructions you’ll find in the e-mail we send you after the registration.
+
+
+## Create an instance
+
+For our web app to work, we need to have a place where we will be running our code and storing files. On platformOS such place is called an _instance_.
+
+In order to create a new instance you need to be logged in the [Partner Portal](https://partners.platformos.com/) and in the left navigation you’ll find a [Create Instance](https://partners.platformos.com/instances/new) link.
+
+The _Instance name_ can be any name of your choice. The only other option you’ll need to be concerned would be choosing the _Data Center_ and _Billing plan_. For the needs of this guide we can use the _Staging_ environment, which is a **completely free** environment designed exactly for testing and developement.
+
+Choosing the _Staging_ data center and clicking on the _Staging Unbilled_ plan should be enough for you to create your first very own instance!
+
+On the list of instances you may initially see your instance marked with _SCHEDULED_TO_ACTIVATE_ status. This proces usually takes only a couple of seconds, so no need to worry.
+
+After a short while you should see the status changed to _Active_ when you refresh the page. This means that we can go to the instance URL visible in the list and actually check if it's working! This URL will be where we’ll see all the code changes so please note it’s importance.
+
+
+## Install pos-cli
+
+The platformOS command line interface – or `pos-cli` – is a tool that will allow you to interact with your instance.
+
+The tool itself offers a variety of options, and we’ll explore it in future sections of this guide, or you can jump right in to [pos-cli documentation](/developer-guide/pos-cli/pos-cli).
+
+**To install pos-cli** you’ll need a recent version of NPM (Node Package Manager) installed on your system. The NPM itself is distributed with Node.js, so we recommend you follow the [official guide for installing Node.js and NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). If you get lost there, it might be the easiest to use [node.js installer](https://nodejs.org/en/download/) that will look just like installing any other program on your system.
+
+Once you have Node.js installed, start your command-line tool of choice and run the following:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+npm install -g @platformos/pos-cli
+</code></pre>
+
+The `-g` attribute means we are installing the tool globally. That might require having a higher system permissions. On unix-based systems that means using sudo and on Windows it might require runing your command-line tool with the administrative rights (it should be available in the right-click context menu).
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+sudo npm install -g @platformos/pos-cli
+</code></pre>
+
+After installing pos-cli you should be able to test if everything ran successfully with the following command:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli -v
+</code></pre>
+
+If everything went smoothly you should be seeing the version number of pos-cli tool that you’ve just installed (for example: `4.7.1`).
+
+
+## Next chapter
+[Working with the code and files](/get-started/working-with-the-code-and-files/)

--- a/app/views/pages/get-started/installation-and-configuration.liquid
+++ b/app/views/pages/get-started/installation-and-configuration.liquid
@@ -20,9 +20,7 @@ Make sure that you’ll verify your account by following the instructions you’
 
 ## Create an instance
 
-For our web app to work, we need to have a place where we will be running our code and storing files. On platformOS such place is called an _instance_.
-
-{% include 'alert/tip', content: 'Each separate site that you can create in the Partner Portal is called an **instance**.' %}
+For our web app to work, we need to have a place where we will be running our code and storing files. On platformOS such place is called an _instance_.{% include 'alert/tip', content: 'Each separate site that you can create in the Partner Portal is called an **instance**.' %}
 
 In order to create a new instance you need to be logged in the [Partner Portal](https://partners.platformos.com/) and in the left navigation you’ll find a [Create Instance](https://partners.platformos.com/instances/new) link.
 
@@ -43,9 +41,7 @@ The tool itself offers a variety of options, and we’ll explore it in future se
 
 **To install pos-cli** you’ll need a recent version of NPM (Node Package Manager) installed on your system. The NPM itself is distributed with Node.js, so we recommend you follow the [official guide for installing Node.js and NPM](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm). If you get lost there, it might be the easiest to use [node.js installer](https://nodejs.org/en/download/) that will look just like installing any other program on your system.
 
-Once you have Node.js installed, start your command-line tool of choice and run the following:
-
-<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+Once you have Node.js installed, start your command-line tool of choice and run the following:<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 npm install -g @platformos/pos-cli
 </code></pre>
 
@@ -64,5 +60,4 @@ pos-cli -v
 If everything went smoothly you should be seeing the version number of pos-cli tool that you’ve just installed (for example: `4.7.1`).
 
 
-## Next chapter
-{% include 'alert/tutorial', content: '[Working with the code and files](/get-started/working-with-the-code-and-files/)' %}
+{% render 'alert/next', content: 'Working with the code and files', url: '/get-started/working-with-the-code-and-files/' %}

--- a/app/views/pages/get-started/working-with-the-code-and-files.liquid
+++ b/app/views/pages/get-started/working-with-the-code-and-files.liquid
@@ -1,28 +1,28 @@
 ---
 metadata:
-  title: Working with the code and files
+  title: Working with the Code and Files
   description: Follow these step-by-step tutorials to set up your development environment and deploy your first platformOS site.
 converter: markdown
 ---
 
-One of the core concepts of platformOS is that you never work offline. You edit the files on your system in your favourite code editor, but you are constantly connected to your instance so that platformOS engine can interpret and parse your codebase.
+One of the core concepts of platformOS is that you never work offline. You edit the files on your system in your favourite code editor, but you are constantly connected to your instance so that the platformOS engine can interpret and parse your codebase.
 
 You write code locally, but it is executed remotely.
 
 
 ## Proper platformOS directory structure
 
-In order for platformOS to understand and properly interpret your code, it needs to be organised in a specific way.
+In order for platformOS to understand and properly interpret your code, it needs to be organized in a specific way.
 
-The simplest method for getting the proper folder structure is to use `pos-cli init` command.
+The simplest method for getting the proper folder structure is to use the `pos-cli init` command.
 
-Let’s start with creating an empty folder – named in this example platforms-hello – for your project and then navigating to it from the command line:
+Start with creating an empty folder – named in this example platforms-hello – for your project and then navigating to it from the command line:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 cd x:\platformos-hello
 </code></pre>
 
-Now, to automatically create the proper directory structure inside that folder you just need to use:
+Now, to automatically create the proper directory structure inside that folder use:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli init
@@ -30,18 +30,18 @@ pos-cli init
 
 The command should return a success message confirming that the directory structure was created.
 
-This means that there are a bunch of new files and folders in your project’s root directory. We’ll get to what are they for in the next steps of this tutorial, or - if you want to jump in to the technical details - check out [platformOS Codebase](/developer-guide/platformos-workflow/codebase) section of this documentation.
+This means that there are a bunch of new files and folders in your project’s root directory. We’ll explain what they are used for in the next steps of this tutorial, or - if you want to jump in to the technical details - check out the [platformOS Codebase](/developer-guide/platformos-workflow/codebase) section of our documentation.
 
 What you need to know for now is that this command creates an example HTML page with a welcome message.
 
 
 ## Authenticate your environment
 
-For pos-cli to know which instance is related to any particular codebase, we need to make a connection between those. Basically, we need to tell pos-cli that our code needs to be visible under some URL.
+For pos-cli to know which instance is related to any particular codebase, you need to make a connection between those. Basically, you need to tell the pos-cli that your code needs to be visible under some URL.
 
 Your instance URL is available in the Partner Portal on the [Instances list](https://partners.platformos.com/instances).
 
-To store your instance URL in the configuration you just need to run a `pos-cli env` add command with your personal data in the parameters:
+To store your instance URL in the configuration, run a `pos-cli env` add command with your personal data in the parameters:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli env add &lt;environment&gt; --email &lt;your email&gt; --url &lt;your instance url&gt;
@@ -49,9 +49,9 @@ pos-cli env add &lt;environment&gt; --email &lt;your email&gt; --url &lt;your in
 
 {% include 'alert/note', content: 'Run all commands discussed in this tutorial in the project root directory.' %}
 
-There is just a single decision here to be made. The `<environment>` parameter is a simple name you need to give your instance. Since you can connect multiple instances to a single codebase, it’s quite often a case where you want to have different environments for development and production.
+You need to give your instance a name in the `<environment>` parameter. Since you can connect multiple instances to a single codebase, quite often you'll want to have different environments for development and production.
 
-Let’s assume the first created instance will be for development, thus we can name it `dev`. So, the example pos-cli command would look like this:
+Let’s assume the first created instance will be for development, thus you can name it `dev`. So, the example pos-cli command would look like this:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli env add dev --email myemail@example.com —-url https://my-instance.staging.oregon.platform-os.com
@@ -66,34 +66,34 @@ Environment <your instance url> as <environment> has been added successfully.
 
 ## Upload your code to an instance
 
-When we have an instance, and pos-cli is configured to connect with it, we would like to send our code to be available under the instance URL.
+When you have an instance, and the pos-cli is configured to connect with it, you can send your code to be available under the instance URL.
 
-This process – called deployment – is a straight-forward operation and you just need to use the following command in the root of your project folder:
+This process – called deployment – is a straight-forward operation where you need to use the following command in the root of your project folder:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli deploy &lt;environment&gt;
 </code></pre>
 
-So, if we named the alias to our instance as <code>dev</code>, the command would look like:
+So, if you named the alias to your instance <code>dev</code>, the command would look like this:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli deploy dev
 </code></pre>
 
-The progress indicator is shown with the deployment status and once it finishes, a message is displayed:
+A progress indicator is shown with the deployment status and once it finishes, a message is displayed:
 
 ```bash
 Deploy succeeded after X seconds
 ```
 
-After this you shall be able to enter the URL of your instance in the browser and it will be showing the example page that we’ve just deployed.
+After this, enter the URL of your instance in the browser and it will display the example page that you’ve just deployed.
 
 
 ### Testing the deployment process
 
-To test out the whole deployment process, let’s make some changes in the code.
+To test out the whole deployment process, make some changes in the code.
 
-If you’re following this guide, you should be able to find a file named `app/views/pages/index.html.liquid` in your codebase. Open it up in your code editor of choice and change any line. For example, let’s locate a line with the welcome message:
+If you’re following this guide, you should be able to find a file named `app/views/pages/index.html.liquid` in your codebase. Open it up in your code editor of choice and change any line. For example, locate a line with the welcome message:
 
 ```html
 Welcome to your Demo instance!
@@ -105,56 +105,56 @@ Try changing it into something more personal like:
 This is my first platfromOS instance!
 ```
 
-Save the file and – as we learned – send the codebase to the instance by running the deploy command in the command line again:
+Save the file and  send the codebase to the instance by running the deploy command in the command line again:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli deploy dev
 </code></pre>
 
-After visiting your instance URL or refreshing previously opened page, you should see the new message there.
+After visiting your instance URL or refreshing the previously opened page, you should see the new message there.
 
 
 ## Upload code changes automatically when you save the file
 
-On a daily basis, you want the instance to immediately reflect the changes you made in the code with a minimum effort on your side.
+On a daily basis, you want the instance to immediately reflect the changes you made in the code with minimum effort on your side.
 
-This process we call **syncing** and it’s handled by a pos-cli command ran from the root project’s directory:
+We call this process **syncing** and it’s handled by a pos-cli command ran from the root project’s directory:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli sync &lt;environment&gt;
 </code></pre>
 
-When executing this command you will learn that it does not end by itself. This is a command that you want to run and leave opened while you make code changes.
+When executing this command you will learn that it does not end by itself. This is a command that you want to run and leave open while you make code changes.
 
-What `pos-cli sync` is doing is basically observing your codebase, so when you save changes in a file – it automatically uploads it to your instance. Just the file that changed so it’s quick and efficient!
+What `pos-cli sync` is doing is basically observing your codebase, so when you save changes in a file – it automatically uploads it to your instance. It only uploads the file that changed so it’s quick and efficient. 
 
 
 ### Syncing in action
 
-For our example we can try another change in the code, but before we’ll do it – let’s start the sync using the following command:
+For this example, try another change in the code, but before you do it, start the sync using the following command:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli sync dev
 </code></pre>
 
-A confirmation message saying that the synchronization has been started should appear, so we can find another place in the code to test how this works. Please find the `Hello world` title in `index.html.liquid` of the demo page and change it to something else, like `Hello beautiful world`.
+A confirmation message saying that the synchronization has been started should appear, so find another place in the code to test how this works. Please find the `Hello world` title in `index.html.liquid` of the demo page and change it to something else, like `Hello beautiful world`.
 
 After the change, just save the file.
 
-In the command line you should see a confirmation message saying that the edited page was synced. Refreshing the page in the browser should confirm that everything worked and the new text content is in place.
+In the command line you should see a confirmation message saying that the edited page was synced. Refreshing the page in the browser should confirm that everything worked and the new text content is displayed.
 
-Syncing handles not only code changes, but also all the other assets. Images, JavaScript files or even GraphQL queries – any change in your project directories will be automatically reflected on your instance. This also includes file renaming and deletion.
+Syncing handles not only code changes, but also all the other assets. Images, JavaScript files, or even GraphQL queries – any change in your project directories will be automatically reflected on your instance. This also includes file renaming and deletion.
 
 
-## Basic overlook on the directory structure
+## Basic overivew of the directory structure
 
-The `pos-cli init` command will create all of the required folders used by platfromOS. The very basic directories you need to be aware of are those used to store files, web pages and handling data.
+The `pos-cli init` command will create all of the required folders used by platformOS. The very basic directories you need to be aware of are those used to store files, web pages, and handling data.
 
-We have a whole separate article [describing each directory](/developer-guide/platformos-workflow/codebase) function in detail if you want to jump directly into the technical aspect. Those four mentioned below are enough to start though.
+We have a whole separate article [describing each directory's](/developer-guide/platformos-workflow/codebase) function in detail if you want to jump directly into the technical aspect. The ones mentioned below are enough to start.
 
 ### Assets
 
-Every **static**, publicly available, **asset** is stored in the app/assets folder. Images, JavaScript, fonts, CSS files or any downloadable documents should go here. You can organize the files any way you want, but you might want consider the following structure to separate various asset types:
+Every **static**, publicly available **asset** is stored in the app/assets folder. Images, JavaScript, fonts, CSS files, or any downloadable documents should go here. You can organize the files any way you want, but you might want to consider the following structure to separate various asset types:
 
 - app/assets/images for images
 - app/assets/scripts for JavaScript files
@@ -167,9 +167,9 @@ Every **page** that you want to create should be placed in app/views/pages. You 
 
 ### Data handling
 
-The **schema** (the structure of your database written in YAML) has it’s place in `app/model_schemas`. We are going to walk through creating them in the next sections of this tutorial.
+The place for **schema** (the structure of your database written in YAML) is `app/model_schemas`. We are going to walk through creating them in the next sections of this tutorial.
 
-**GraphQL** queries and mutations are used to get the data from the database or save data in it. All of those queries have their place in `app/graphql`.
+**GraphQL** queries and mutations are used to get the data from the database or save data in it. All of those queries go to `app/graphql`.
 
 
 {% render 'alert/next', content: 'Build a ToDo List App', url: '/get-started/todo-app/build-todo-list-app' %}

--- a/app/views/pages/get-started/working-with-the-code-and-files.liquid
+++ b/app/views/pages/get-started/working-with-the-code-and-files.liquid
@@ -1,0 +1,176 @@
+---
+metadata:
+  title: Working with the code and files
+  description: Follow these step-by-step tutorials to set up your development environment and deploy your first platformOS site.
+converter: markdown
+---
+
+One of the core concepts of platformOS is that you never work offline. You edit the files on your system in your favourite code editor, but you are constantly connected to your instance so that platformOS engine can interpret and parse your codebase.
+
+You write code locally, but it is executed remotely.
+
+
+## Proper platformOS directory structure
+
+In order for platformOS to understand and properly interpret your code, it needs to be organised in a specific way.
+
+The simplest method for getting the proper folder structure is to use pos-cli’s init command.
+
+Let’s start with creating an empty folder – named in this example platforms-hello – for your project and then navigating to it from the command line:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+cd x:\platformos-hello
+</code></pre>
+
+Now, to automatically create the proper directory structure inside that folder you just need to use:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli init
+</code></pre>
+
+The command should return a success message confirming that the directory structure was created.
+
+This means that there are a bunch of new files and folders in your project’s root directory. We’ll get to what are they for in the next steps of this tutorial, or - if you want to jump in to the technical details - check out [platformOS Codebase](/developer-guide/platformos-workflow/codebase) section of this documentation.
+
+What you need to know for now is that this command creates an example HTML page with a welcome message.
+
+
+## Authenticate your environment
+
+For pos-cli to know which instance is related to any particular codebase, we need to make a connection between those. Basically, we need to tell pos-cli that our code needs to be visible under some URL.
+
+Your instance URL is available in the Partner Portal on the [Instances list](https://partners.platformos.com/instances).
+
+To store your instance URL in the configuration you just need to run a pos-cli’s env add command with your personal data in the parameters:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli env add &lt;environment&gt; --email &lt;your email&gt; --url &lt;your instance url&gt;
+</code></pre>
+
+There is just a single decision here to be made. The `<environment>` parameter is a simple name you need to give your instance. Since you can connect multiple instances to a single codebase, it’s quite often a case where you want to have different environments for development and production.
+
+Let’s assume the first created instance will be for development, thus we can name it `dev`. So, the example pos-cli command would look like this:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli env add dev --email myemail@example.com —-url https://my-instance.staging.oregon.platform-os.com
+</code></pre>
+
+After running this command, you’ll get asked for your Partner Portal password to authenticate. Providing the correct password will be confirmed by pos-cli:
+
+```bash
+Environment <your instance url> as <environment> has been added successfully.
+```
+
+
+## Upload your code to an instance
+
+When we have an instance, and pos-cli is configured to connect with it, we would like to send our code to be available under the instance URL.
+
+This process – called deployment – is a straight-forward operation and you just need to use the following command in the root of your project folder:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli deploy &lt;environment&gt;
+</code></pre>
+
+So, if we named the alias to our instance as <code>dev</code>, the command would look like:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli deploy dev
+</code></pre>
+
+The progress indicator is shown with the deployment status and once it finishes, a message is displayed:
+
+```bash
+Deploy succeeded after X seconds
+```
+
+After this you shall be able to enter the URL of your instance in the browser and it will be showing the example page that we’ve just deployed.
+
+
+### Testing the deployment process
+
+To test out the whole deployment process, let’s make some changes in the code.
+
+If you’re following this guide, you should be able to find a file named index.html.liquid in your codebase. Open it up in your code editor of choice and change any line. For example let’s locate a line with the welcome message:
+
+```html
+Welcome to your Demo instance!
+```
+
+Try changing it into something more personal like:
+
+```html
+This is my first platfromOS instance!
+```
+
+Save the file and – as we learned – send the codebase to the instance by running the deploy command in the command line again:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli deploy dev
+</code></pre>
+
+After visiting your instance URL or refreshing previously opened page, you should see the new message there.
+
+Ok, this works, but having to manually deploy each change would take far too much time. You wouldn’t want to enter any commands or wait so long for the pos-cli to send all of the files in your codebase each time you change a single line of your code. Because this is what the deploy command is doing – sending all the files in the codebase to the instance.
+
+
+## Upload code changes automatically when you save the file
+
+On a daily basis, you want the instance to immediately reflect the changes you made in the code with a minimum effort on your side.
+
+This process we call **syncing** and it’s handled by a pos-cli command ran from the root project’s directory:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli sync &lt;environment&gt;
+</code></pre>
+
+When executing this command you will learn that it does not end by itself. This is a command that you want to run and leave opened while you make code changes.
+
+What `pos-cli sync` is doing is basically observing your codebase, so when you save changes in a file – it automatically uploads it to your instance. Just the file that changed so it’s quick and efficient!
+
+
+### Syncing in action
+
+For our example we can try another change in the code, but before we’ll do it – let’s start the sync using the following command:
+
+<pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
+pos-cli sync dev
+</code></pre>
+
+A confirmation message saying that the synchronization has been started should appear, so we can find another place in the code to test how this works. Please find the `Hello world` title in `index.html.liquid` of the demo page and change it to something else, like `Hello beautiful world`.
+
+After the change, just save the file.
+
+In the command line you should see a confirmation message saying that the edited page was synced. Refreshing the page in the browser should confirm that everything worked and the new text content is in place.
+
+Syncing handles not only code changes, but also all the other assets. Images, JavaScript files or even GraphQL queries – any change in your project directories will be automatically reflected on your instance.
+
+
+## Basic overlook on the directory structure
+
+The `pos-cli init` command will create all of the required folders used by platfromOS. The very basic directories you need to be aware of are those used to store files, web pages and handling data.
+
+We have a whole separate article [describing each directory](/developer-guide/platformos-workflow/codebase) function in detail if you want to jump directly into the technical aspect. Those four mentioned below are enough to start though.
+
+### Assets
+
+Every **static**, publicly available, **asset** is stored in the app/assets folder. Images, JavaScript, fonts, CSS files or any downloadable documents should go here. We recommend a standarized set of subfolders for each type, so:
+
+- app/assets/images for images
+- app/assets/scripts for JavaScript files
+- app/assets/styles for the page CSS
+- app/assets/fonts for the font files
+
+### Subpages
+
+Every **subpage** that you want to create should be placed in app/views/pages. You can use pure HTML and extend it with Liquid.
+
+### Data handling
+
+The **schema** (the structure of your database written in YAML) has it’s place in `app/model_schemas`. We are going to walk through creating them in the next sections of this tutorial.
+
+**GraphQL** queries are used to get the data from the database or save data in it. All of those queries have their place in `app/graphql`.
+
+
+## Next chapter
+[Build a ToDo List App](/get-started/todo-app/build-todo-list-app)

--- a/app/views/pages/get-started/working-with-the-code-and-files.liquid
+++ b/app/views/pages/get-started/working-with-the-code-and-files.liquid
@@ -172,5 +172,4 @@ The **schema** (the structure of your database written in YAML) has it’s place
 **GraphQL** queries and mutations are used to get the data from the database or save data in it. All of those queries have their place in `app/graphql`.
 
 
-## Next chapter
-{% include 'alert/tutorial', content: '[Build a ToDo List App](/get-started/todo-app/build-todo-list-app)' %}
+{% render 'alert/next', content: 'Build a ToDo List App', url: '/get-started/todo-app/build-todo-list-app' %}

--- a/app/views/pages/get-started/working-with-the-code-and-files.liquid
+++ b/app/views/pages/get-started/working-with-the-code-and-files.liquid
@@ -175,4 +175,4 @@ The **schema** (the structure of your database written in YAML) has it’s place
 
 
 ## Next chapter
-[Build a ToDo List App](/get-started/todo-app/build-todo-list-app)
+{% include 'alert/tutorial', content: '[Build a ToDo List App](/get-started/todo-app/build-todo-list-app)' %}

--- a/app/views/pages/get-started/working-with-the-code-and-files.liquid
+++ b/app/views/pages/get-started/working-with-the-code-and-files.liquid
@@ -47,6 +47,8 @@ To store your instance URL in the configuration you just need to run a pos-cli�
 pos-cli env add &lt;environment&gt; --email &lt;your email&gt; --url &lt;your instance url&gt;
 </code></pre>
 
+{% include 'alert/note', content: 'Run all commands discussed in this tutorial in the project root directory.' %}
+
 There is just a single decision here to be made. The `<environment>` parameter is a simple name you need to give your instance. Since you can connect multiple instances to a single codebase, it’s quite often a case where you want to have different environments for development and production.
 
 Let’s assume the first created instance will be for development, thus we can name it `dev`. So, the example pos-cli command would look like this:

--- a/app/views/pages/get-started/working-with-the-code-and-files.liquid
+++ b/app/views/pages/get-started/working-with-the-code-and-files.liquid
@@ -14,7 +14,7 @@ You write code locally, but it is executed remotely.
 
 In order for platformOS to understand and properly interpret your code, it needs to be organised in a specific way.
 
-The simplest method for getting the proper folder structure is to use pos-cli’s init command.
+The simplest method for getting the proper folder structure is to use `pos-cli init` command.
 
 Let’s start with creating an empty folder – named in this example platforms-hello – for your project and then navigating to it from the command line:
 
@@ -41,7 +41,7 @@ For pos-cli to know which instance is related to any particular codebase, we nee
 
 Your instance URL is available in the Partner Portal on the [Instances list](https://partners.platformos.com/instances).
 
-To store your instance URL in the configuration you just need to run a pos-cli’s env add command with your personal data in the parameters:
+To store your instance URL in the configuration you just need to run a `pos-cli env` add command with your personal data in the parameters:
 
 <pre class="command-line" data-user="user" data-host="host"><code class="language-bash">
 pos-cli env add &lt;environment&gt; --email &lt;your email&gt; --url &lt;your instance url&gt;
@@ -93,7 +93,7 @@ After this you shall be able to enter the URL of your instance in the browser an
 
 To test out the whole deployment process, let’s make some changes in the code.
 
-If you’re following this guide, you should be able to find a file named index.html.liquid in your codebase. Open it up in your code editor of choice and change any line. For example let’s locate a line with the welcome message:
+If you’re following this guide, you should be able to find a file named `app/views/pages/index.html.liquid` in your codebase. Open it up in your code editor of choice and change any line. For example, let’s locate a line with the welcome message:
 
 ```html
 Welcome to your Demo instance!
@@ -112,8 +112,6 @@ pos-cli deploy dev
 </code></pre>
 
 After visiting your instance URL or refreshing previously opened page, you should see the new message there.
-
-Ok, this works, but having to manually deploy each change would take far too much time. You wouldn’t want to enter any commands or wait so long for the pos-cli to send all of the files in your codebase each time you change a single line of your code. Because this is what the deploy command is doing – sending all the files in the codebase to the instance.
 
 
 ## Upload code changes automatically when you save the file
@@ -145,7 +143,7 @@ After the change, just save the file.
 
 In the command line you should see a confirmation message saying that the edited page was synced. Refreshing the page in the browser should confirm that everything worked and the new text content is in place.
 
-Syncing handles not only code changes, but also all the other assets. Images, JavaScript files or even GraphQL queries – any change in your project directories will be automatically reflected on your instance.
+Syncing handles not only code changes, but also all the other assets. Images, JavaScript files or even GraphQL queries – any change in your project directories will be automatically reflected on your instance. This also includes file renaming and deletion.
 
 
 ## Basic overlook on the directory structure
@@ -156,22 +154,22 @@ We have a whole separate article [describing each directory](/developer-guide/pl
 
 ### Assets
 
-Every **static**, publicly available, **asset** is stored in the app/assets folder. Images, JavaScript, fonts, CSS files or any downloadable documents should go here. We recommend a standarized set of subfolders for each type, so:
+Every **static**, publicly available, **asset** is stored in the app/assets folder. Images, JavaScript, fonts, CSS files or any downloadable documents should go here. You can organize the files any way you want, but you might want consider the following structure to separate various asset types:
 
 - app/assets/images for images
 - app/assets/scripts for JavaScript files
 - app/assets/styles for the page CSS
 - app/assets/fonts for the font files
 
-### Subpages
+### Page
 
-Every **subpage** that you want to create should be placed in app/views/pages. You can use pure HTML and extend it with Liquid.
+Every **page** that you want to create should be placed in app/views/pages. You can use pure HTML and extend it with Liquid.
 
 ### Data handling
 
 The **schema** (the structure of your database written in YAML) has it’s place in `app/model_schemas`. We are going to walk through creating them in the next sections of this tutorial.
 
-**GraphQL** queries are used to get the data from the database or save data in it. All of those queries have their place in `app/graphql`.
+**GraphQL** queries and mutations are used to get the data from the database or save data in it. All of those queries have their place in `app/graphql`.
 
 
 ## Next chapter

--- a/app/views/partials/alert/next.liquid
+++ b/app/views/partials/alert/next.liquid
@@ -1,0 +1,10 @@
+<div class="mt-4 text-right">
+  <div class="p-6 inline-block border-top border-pos-divider bg-pos-note-bg">
+    <div class="text-pos-note-text no-underline text-left">Read next:</div>
+    <a href="{{ url }}" class="pt-1 flex items-center">
+      {{ content }}
+
+      <svg class="pl-5 ml-5 w-4 box-content border-l border-pos-divider text-pos-blue" viewBox="0 0 24 24" fill="currentColor" class="w-4" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg"><path d="M12.75 23.25a.752.752 0 0 1-.53-1.281l9.22-9.22H.75a.749.749 0 1 1 0-1.499h20.689l-9.22-9.22A.746.746 0 0 1 12.22.97c.141-.142.33-.22.53-.22s.389.078.53.22l10.5 10.5a.74.74 0 0 1 .163.245l.01.026a.73.73 0 0 1 0 .517l-.006.016a.755.755 0 0 1-.168.257L13.28 23.03a.743.743 0 0 1-.53.22z"/></svg>
+    </a>
+  </div>
+</div>

--- a/app/views/partials/shared/nav/get-started.liquid
+++ b/app/views/partials/shared/nav/get-started.liquid
@@ -2,17 +2,25 @@
   <a href="/get-started">Introduction</a>
 </li>
 
-<li class="{% if cp contains '/hello-world' %}active{% endif %}">
-  <a href="/get-started/hello-world/hello-world">Hello, World!</a>
+<li class="{% if cp contains '/get-started/installation-and-configuration' %}active{% endif %}">
+  <a href="/get-started/installation-and-configuration/">Installation and configuration</a>
 
   <ul class="submenu">
-    {% include "shared/nav/link", href: "/get-started/hello-world/hello-world#prerequisite-register-on-the-partner-portal", text: "Prerequisite: Register on the Partner Portal" %}
-    {% include "shared/nav/link", href: "/get-started/hello-world/hello-world#step-1-create-an-instance", text: "1. Create an Instance" %}
-    {% include "shared/nav/link", href: "/get-started/hello-world/hello-world#step-2-install-the-pos-cli", text: "2. Install the pos-cli" %}
-    {% include "shared/nav/link", href: "/get-started/hello-world/hello-world#step-3-create-your-codebase", text: "3. Create your codebase" %}
-    {% include "shared/nav/link", href: "/get-started/hello-world/hello-world#step-4-change-something-on-your-homepage", text: "4. Change something on your homepage" %}
-    {% include "shared/nav/link", href: "/get-started/hello-world/hello-world#step-5-authenticate-your-environment", text: "5. Authenticate your environment" %}
-    {% include "shared/nav/link", href: "/get-started/hello-world/hello-world#step-6-deploy-or-sync", text: "6. Deploy or sync" %}
+    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#sign-up-on-partner-portal", text: "Sign up on Partner Portal" %}
+    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#create-an-instance", text: "Create an instance" %}
+    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#install-pos-cli", text: "Install pos-cli" %}
+  </ul>
+</li>
+
+<li class="{% if cp contains '/get-started/working-with-the-code-and-files' %}active{% endif %}">
+  <a href="/get-started/working-with-the-code-and-files/">Working with the code and files</a>
+
+  <ul class="submenu">
+    {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#proper-platformos-directory-structure", text: "Proper platformOS directory structure" %}
+    {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#authenticate-your-environment", text: "Authenticate your environment" %}
+    {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#upload-your-code-to-an-instance", text: "Upload your code to an instance" %}
+    {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#upload-code-changes-automatically-when-you-save-the-file", text: "Upload code changes automatically when you save the file" %}
+    {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#basic-overlook-on-the-directory-structure", text: "Basic overlook on the directory structure" %}
   </ul>
 </li>
 

--- a/app/views/partials/shared/nav/get-started.liquid
+++ b/app/views/partials/shared/nav/get-started.liquid
@@ -6,17 +6,17 @@
   <a href="/get-started/installation-and-configuration/">Installation and configuration</a>
 
   <ul class="submenu">
-    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#sign-up-on-partner-portal", text: "Sign up on Partner Portal" %}
-    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#create-an-instance", text: "Create an instance" %}
-    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#install-pos-cli", text: "Install pos-cli" %}
+    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#sign-up-on-partner-portal", text: "Sign up on the Partner Portal" %}
+    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#create-an-instance", text: "Create an Instance" %}
+    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#install-pos-cli", text: "Install the pos-cli" %}
   </ul>
 </li>
 
 <li class="{% if cp contains '/get-started/working-with-the-code-and-files' %}active{% endif %}">
-  <a href="/get-started/working-with-the-code-and-files/">Working with the code and files</a>
+  <a href="/get-started/working-with-the-code-and-files/">Working with the Code and Files</a>
 
   <ul class="submenu">
-    {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#proper-platformos-directory-structure", text: "Proper platformOS directory structure" %}
+    {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#proper-platformos-directory-structure", text: "The platformOS directory structure" %}
     {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#authenticate-your-environment", text: "Authenticate your environment" %}
     {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#upload-your-code-to-an-instance", text: "Upload your code to an instance" %}
     {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#upload-code-changes-automatically-when-you-save-the-file", text: "Upload code changes automatically when you save the file" %}


### PR DESCRIPTION
- Updated the onboarding content not to include obsolete information
- Divided the onboarding into separate self-explaining sections
- Added an onboarding section about working being connected to instance
- Added an onboarding section explaining basic folder structure that will be needed to build the app in the To do tutorial
- Simplified the docs so there is just one path without any distractions and unneeded information for any new reader

I do believe that @Slashek should be the first one to review this and @diana-lakatos after not to duplicate work if I'd have to update some technical descriptions.

Preview: https://lk-documentation.staging.oregon.platform-os.com