### PR TITLE
Fixes links in Get Started navigation

### DIFF
--- a/app/views/pages/get-started.liquid
+++ b/app/views/pages/get-started.liquid
@@ -1,6 +1,6 @@
 ---
 metadata:
-  title: Get Started
+  title: Get Started — Introduction
   description: Follow these step-by-step tutorials to set up your development environment and deploy your first platformOS site.
 converter: markdown
 ---

--- a/app/views/pages/get-started/installation-and-configuration.liquid
+++ b/app/views/pages/get-started/installation-and-configuration.liquid
@@ -26,11 +26,11 @@ In order to create a new instance you need to be logged in the [Partner Portal](
 
 The _Instance name_ can be any name of your choice. The only other options you’ll need to choose are the _Data Center_ and _Billing plan_. For the needs of this guide we can use the _Staging_ environment, which is a **completely free** environment designed for testing and developement.
 
-Choosing the _Staging_ data center and clicking on the _Staging Unbilled_ plan should be enough for you to create your first instance. 
+Choosing the _Staging_ data center and clicking on the _Staging Unbilled_ plan should be enough for you to create your first instance.
 
 On the list of instances, you may initially see your instance marked with the _SCHEDULED_TO_ACTIVATE_ status. This process usually takes only a couple of seconds.
 
-After a short while, you should see the status changed to _Active_ when you refresh the page. This means that you can go to the instance URL visible in the list and check if it's working. This URL is important: you’ll see all the code changes here. 
+After a short while, you should see the status changed to _Active_ when you refresh the page. This means that you can go to the instance URL visible in the list and check if it's working. This URL is important: you’ll see all the code changes here.
 
 
 ## Install pos-cli

--- a/app/views/partials/shared/nav/get-started.liquid
+++ b/app/views/partials/shared/nav/get-started.liquid
@@ -3,10 +3,10 @@
 </li>
 
 <li class="{% if cp contains '/get-started/installation-and-configuration' %}active{% endif %}">
-  <a href="/get-started/installation-and-configuration/">Installation and configuration</a>
+  <a href="/get-started/installation-and-configuration/">Installation and Configuration</a>
 
   <ul class="submenu">
-    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#sign-up-on-partner-portal", text: "Sign up on the Partner Portal" %}
+    {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#sign-up-on-the-partner-portal", text: "Sign up on the Partner Portal" %}
     {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#create-an-instance", text: "Create an Instance" %}
     {% include "shared/nav/link", href: "/get-started/installation-and-configuration/#install-pos-cli", text: "Install the pos-cli" %}
   </ul>
@@ -20,7 +20,7 @@
     {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#authenticate-your-environment", text: "Authenticate your environment" %}
     {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#upload-your-code-to-an-instance", text: "Upload your code to an instance" %}
     {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#upload-code-changes-automatically-when-you-save-the-file", text: "Upload code changes automatically when you save the file" %}
-    {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#basic-overlook-on-the-directory-structure", text: "Basic overlook on the directory structure" %}
+    {% include "shared/nav/link", href: "/get-started/working-with-the-code-and-files/#basic-overview-of-the-directory-structure", text: "Basic overview of the directory structure" %}
   </ul>
 </li>
 


### PR DESCRIPTION
Fixes anchor links in Get Started navigation after copy edits in headings.
Adds Introduction to Get Started title to better reflect breadcrumb based on @Nagygyorgy's feedback.

Preview: https://diana-documentation.staging.oregon.platform-os.com/get-started

@z-x Please review, thank you! 
