### PR TITLE
docs (structure): Remove CodeKit

### DIFF
--- a/app/views/pages/kits.liquid
+++ b/app/views/pages/kits.liquid
@@ -37,9 +37,9 @@ As we were working on the Golden Platform initiative, it evolved into a system o
 
 Below is an outline of each of the kits we’re working on:
 
-* **CodeKit**: Increase your profits by substantially reducing time to build scalable platform ecosystems. An extensive portfolio of modular code provides performant Minimal Viable Products for eCommerce Marketplaces, sophisticated Service Marketplaces and Community Portals. And create your own SaaS and mobile apps without limits.
+* **DevKit**: Combine platfomrOS modules freeely to build any type of application. Work as you have always, or leverage the Mac/Linux/PC command line interface tool pos-cli. Spin up Staging, UAT and Production server instances and follow CI/CD best practice. Our RunTime engine will leverage built-in Domain Specific Languages; GraphQL and Liquid Markup and we provide examples for popular frontend frameworks like REACT, Angular, Svelte, Vue, and more.
 
-* **DevKit**: Work as you have always, or leverage the Mac/Linux/PC command line interface tool pos-cli. Spin up Staging, UAT and Production server instances and follow CI/CD best practice. Our RunTime engine will leverage built-in Domain Specific Languages; GraphQL and Liquid Markup and we provide examples for popular frontend frameworks like REACT, Angular, Svelte, Vue, and more.
+* **CodeKit**: Increase your profits by substantially reducing time to build scalable platform ecosystems. An extensive portfolio of modular code will provide performant Minimal Viable Products for eCommerce Marketplaces, sophisticated Service Marketplaces and Community Portals. And create your own SaaS and mobile apps without limits.
 
 * **DevOpsKit**: If you're sick of the massive cost and time to build, manage, and maintain core infrastructure, platformOS handles this all for you seamlessly. We support AWS, GCP or OCI - with multi-tenanted and dedicated server environments. Leverage clustered REDIS, ElasticSearch and Postgres environments without you needing to worry about any DevOps tasks, saving you thousands per month in DevOps engineering costs.
 

--- a/app/views/partials/home/section-kits.liquid
+++ b/app/views/partials/home/section-kits.liquid
@@ -1,7 +1,7 @@
 <div class="bg-white mt-10 md:mt-12 md:mb-12">
   <div class="grid md:grid-cols-2">
     <div class="shadow-sm hover:shadow-inner md:pl-12 md:pt-12">
-      <a href="/kits/devkit/pos-cli" class="flex items-center h-full p-4 no-underline border-1 sm:p-8 text-body hover:text-pos-darkblue">
+      <a href="/kits/modular-architecture/introduction" class="flex items-center h-full p-4 no-underline border-1 sm:p-8 text-body hover:text-pos-darkblue">
         <img src="{{ 'images/svg/sections/dev-kit.svg' | asset_url }}"/>
 
         <div class="ml-4">
@@ -11,16 +11,6 @@
       </a>
     </div>
 
-    <div class="shadow-sm hover:shadow-inner md:pt-12 md:pr-12">
-      <a href="/kits/modular-architecture/introduction" class="flex items-center h-full p-4 no-underline border-1 sm:p-8 text-body hover:text-pos-darkblue">
-        <img src="{{ 'images/svg/sections/code-kit.svg' | asset_url }}"/>
-
-        <div class="ml-4">
-          <h2 class="mb-6 text-lg font-bold hover:text-pos-blue">CodeKit</h2>
-          <p>Explore pre-made modular code for various features.</p>
-        </div>
-      </a>
-    </div>
 
     <div class="shadow-sm hover:shadow-inner md:pl-12 md:pb-12">
       <a href="/kits/ui/platformos-design-kit" class="flex items-center h-full p-4 no-underline border-1 sm:p-8 text-body hover:text-pos-darkblue">
@@ -33,15 +23,6 @@
       </a>
     </div>
 
-    <div class="shadow-sm hover:shadow-inner md:pb-12 md:pr-12">
-      <a href="/kits" class="flex items-center h-full p-4 no-underline border-1 sm:p-8 text-body hover:text-pos-darkblue">
-        <img src="{{ 'images/svg/sections/pos-kits.svg' | asset_url }}"/>
 
-        <div class="ml-4">
-          <h2 class="mb-6 text-lg font-bold hover:text-pos-blue">platformOS Kits</h2>
-          <p>Learn about pre-built solutions for development, UX, UI, mobile, and documentation.</p>
-        </div>
-      </a>
-    </div>
   </div>
 </div>

--- a/app/views/partials/home/section-options.liquid
+++ b/app/views/partials/home/section-options.liquid
@@ -63,8 +63,8 @@
         <svg class="w-10 h-10 flex-shrink-0"><title>Standards</title><use xlink:href="#src-6"></use></svg>
 
         <div class="ml-4">
-          <h2 class="mb-6 text-lg font-bold hover:text-pos-blue">Standards</h2>
-          <p>Learn about the standards of platformOS development through examples from our Golden Platform.</p>
+          <h2 class="mb-6 text-lg font-bold hover:text-pos-blue">platformOS Kits</h2>
+          <p>Learn about pre-built solutions for development, UX, UI, mobile, and documentation.</p>
         </div>
       </a>
     </div>

--- a/app/views/partials/shared/nav/kits.liquid
+++ b/app/views/partials/shared/nav/kits.liquid
@@ -1,5 +1,5 @@
 <li class="mt-6 mb-2 text-base topic-group">
-  <h3 class="text-base uppercase">CodeKit</h3>
+  <h3 class="text-base uppercase">DevKit</h3>
 </li>
 
 <li class="{% if cp contains 'modular-architecture/introduction' %}active{% endif %}">
@@ -45,7 +45,7 @@
 </li>
 
 <li class="mt-6 mb-2 text-base topic-group">
-  <h3 class="text-base uppercase">DevKit</h3>
+  <h3 class="text-base">Tools</h3>
 </li>
 
 <li class="{% if cp contains 'devkit/pos-cli' %}active{% endif %}">


### PR DESCRIPTION
- Removes the CodeKit from the home page.
- Removes platformOS Kits section to make the number of kits sections even.
- Removes the CodeKit from the platformOS Kits navigation. 
- Rearranges DevKit topics in navigation. 
- Adds platformOS Kits in place of Standards.

Preview: https://diana-documentation.staging.oregon.platform-os.com/