### PR TITLE
Update saving-data-to-the-database.liquid

### DIFF
--- a/app/views/pages/get-started/build-your-first-app/saving-data-to-the-database.liquid
+++ b/app/views/pages/get-started/build-your-first-app/saving-data-to-the-database.liquid
@@ -61,7 +61,7 @@ How can you make sure that the table you’ve just created is really there in th
 For this purpose, we have created a tool that allows you to browse through the tables and edit the records. Run this command to start the tool:
 
 ```bash
-pos-cli gui serve dev
+pos-cli gui serve staging
 ```
 
 This starts an application to help you administer your instance. When the application is running you can go to [http://localhost:3333](http://localhost:3333) in your browser.


### PR DESCRIPTION
Basing the instructions off the fact that the Partner Portal sets us up to use staging and not dev. So when dev is used you just get errors. Keeping the serve as staging fluid throughout the doc would help