### PR TITLE
Update retrieving-and-presenting-the-data-on-the-page.liquid

### DIFF
--- a/app/views/pages/get-started/build-your-first-app/retrieving-and-presenting-the-data-on-the-page.liquid
+++ b/app/views/pages/get-started/build-your-first-app/retrieving-and-presenting-the-data-on-the-page.liquid
@@ -52,7 +52,7 @@ Before using the query on your page, it would be a good idea to test if it works
 To test the query, you are going to use one of the tools built in the `pos-cli`. To start the tool, use the following command:
 
 ```bash
-pos-cli gui serve dev
+pos-cli gui serve staging
 ```
 
 When the application is running, go to [http://localhost:3333](http://localhost:3333) in your browser and choose _Go to GraphiQL_. Paste the GraphQL query you’ve just written to the text area on left. Pressing the big play button on top should result in the output of the query being presented in the right column.


### PR DESCRIPTION
another instance where dev shouldn't be used if following the partner portal cheat sheet. But https://documentation.platformos.com/get-started/working-with-the-code-and-files/ references that they named it dev so its confusing.