### PR TITLE
Update developing-graphql-queries-using-pos-cli-gui.liquid

### DIFF
--- a/app/views/pages/kits/devkit/developing-graphql-queries-using-pos-cli-gui.liquid
+++ b/app/views/pages/kits/devkit/developing-graphql-queries-using-pos-cli-gui.liquid
@@ -56,7 +56,7 @@ For our documentation it shows: `platformOS - https://documentation.platformos.c
 
 ### Main editor window
 
-This is the main area where you type queries and mutations to run against the environment. It is similar to your code editor in a way. It has line numbers, code folding, and even [keyboard shortcuts](https://defkey.com/codemirror-shortcuts) known from other editors. Not all of them are listed in the official documentation, but it is a good start.
+This is the main area where you type queries and mutations to run against the environment. It is similar to your code editor. It has line numbers, code folding, and even [keyboard shortcuts](https://defkey.com/codemirror-shortcuts) known from other editors. Not all of them are listed in the official documentation, but it is a good start.
 
 Worth mentioning here are:
 
@@ -78,7 +78,7 @@ If you wish to not have this step, you can either remove queries you don't need,
 
 <img loading="lazy" src="{{ 'images/graphiql/comments.png' | asset_url }}" alt="Comments in GraphQL" />
 
-If you don't know what you can use in any given moment you can press CTRL+SPACE to check if there are any autocomplete options. This way you don't have to have documentation open when writing.
+If you don't know what options you can use, you can press CTRL+SPACE to check if there are any autocomplete options. This way you don't have to have documentation open when writing.
 
 <img loading="lazy" src="{{ 'images/graphiql/autocomplete.png' | asset_url }}" alt="Autocomplete in GraphiQL" />
 
@@ -115,7 +115,7 @@ GraphQL queries accept JSON format, which means it has to be an object and key n
 
 ### Explorer
 
-Click the `Explorer` button above main editor window to open the explorer.
+Click the `Explorer` button above the main editor window to open the explorer.
 
 The explorer is an interactive query builder which can speed up your query creation. It has two main sections - queries and mutations.
 
@@ -146,10 +146,10 @@ Example history:
 
 <img loading="lazy" src="{{ 'images/graphiql/history.png' | asset_url }}" alt="Screenshot of History listing previous queries" />
 
-Named queries are displayed by their names, unnamed are showing the beginning of the code.
+Named queries are displayed by their names, unnamed queries show the beginning of the code block they are in.
 
 ### Prettify
 
-If you want to apply default code formatting provided by GraphiQL, click on the "Prettify" button on the top. It is not the best solution out there, but for quick prototyping it is better than nothing.
+If you want to apply default code formatting provided by GraphiQL, click on the "Prettify" button at the top. It is not the best solution out there, but for quick prototyping it is better than nothing.
 
-After you are finished with your query, and copied it over to your `.graphql` file, we recommend using [Prettier](https://prettier.io/), usually not directly, but using a plugin to your favorite editor, to format the code even better, and more consistently with your code style guide.
+After you are finished with your query, and have copied it over to your `.graphql` file, we recommend using [Prettier](https://prettier.io/), usually not directly, but using a plugin for your favorite editor, to format the code even better, and more consistently with your code style guide.


### PR DESCRIPTION
It is similar to your code editor in a way > remove “in a way” you can use in any given moment > options you can use, above > above the
unnamed are showing the beginning of the code. > unnamed queries show the beginning of the code block they are in. on the top > at the top
and copied > and have copied
plugin to your favorite editor > plugin for your favorite editor