### PR TITLE
Syntax property in documentation

### DIFF
--- a/app/views/partials/api/liquid/platformos_filters.liquid
+++ b/app/views/partials/api/liquid/platformos_filters.liquid
@@ -23,6 +23,7 @@
       "description": {% print item.description | json %},
       "summary": "{% print item.decription | join: ', ' | default: default_description %}",
       "syntax": "{% print first_param_type %} | {% print item.name %}",
+      "platformOS": true,
       "name": "{% print item.name %}",
       "aliases": {% print item.aliases | json %},
       "parameters": [

--- a/app/views/partials/api/liquid/platformos_tags.liquid
+++ b/app/views/partials/api/liquid/platformos_tags.liquid
@@ -3,11 +3,11 @@
   {%- for item in data.tags -%}
     {% if item.name == blank %}{% continue %}{% endif %}
     {
-    "category": "{{ item.category | default: 'platformOS' }}",
+      "category": "{{ item.category | default: 'platformOS' }}",
       "deprecated": {{ item.deprecated | default: false | json }},
       "deprecation_reason": "{{item.deprecated | join: ', '}}",
       "description": {{ item.description | json }},
-      "syntax": {{ item.examples.first | json }},
+      "syntax": {{ item.syntax | json }},
       "name": "{{item.name}}",
       "parameters": [
         {% for param in item.params %}

--- a/app/views/partials/api/liquid/platformos_tags.liquid
+++ b/app/views/partials/api/liquid/platformos_tags.liquid
@@ -8,6 +8,7 @@
       "deprecation_reason": "{{item.deprecated | join: ', '}}",
       "description": {{ item.description | json }},
       "syntax": {{ item.syntax | json }},
+      "platformOS": true,
       "name": "{{item.name}}",
       "parameters": [
         {% for param in item.params %}


### PR DESCRIPTION
This PR modifies how tags, filters and objects json files are rendered to include proper syntax and platformOS tag marker to enable autocomplete support in the vs extension.